### PR TITLE
fix: correct scoring algorithm, add error boundaries, code splitting, and production routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ dist-ssr
 
 # Agent-generated plans (not part of the codebase)
 app/plans/
+
+# Agent tool directories
+.claude/
+.junie/
+.qoder/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 *.pdf
+
+# Agent-generated plans (not part of the codebase)
+app/plans/

--- a/app/.antigravitycli/d2c01658-51f9-4cf0-af7a-d270f373e3ae.json
+++ b/app/.antigravitycli/d2c01658-51f9-4cf0-af7a-d270f373e3ae.json
@@ -1,0 +1,1 @@
+/home/luandro/.gemini/config/projects/d2c01658-51f9-4cf0-af7a-d270f373e3ae.json

--- a/app/.env.production
+++ b/app/.env.production
@@ -1,0 +1,1 @@
+VITE_ROUTER_BASENAME=/community-box/

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -74,6 +74,7 @@
         "@eslint/js": "^9.39.4",
         "@tailwindcss/postcss": "^4.2.2",
         "@tailwindcss/typography": "^0.5.19",
+        "@testing-library/jest-dom": "^6.9.1",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -88,8 +89,16 @@
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.2",
-        "vite": "^8.0.8"
+        "vite": "^8.0.8",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2503,9 +2512,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2523,9 +2529,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,9 +2546,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,9 +2563,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2583,9 +2580,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2603,9 +2597,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2804,9 +2795,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2824,9 +2812,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2844,9 +2829,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2864,9 +2846,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2884,9 +2863,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -2904,9 +2880,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3126,9 +3099,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3146,9 +3116,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3166,9 +3133,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3186,9 +3150,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3315,6 +3276,26 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3324,6 +3305,17 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -3397,6 +3389,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3823,6 +3822,119 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3907,6 +4019,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/autoprefixer": {
@@ -4088,6 +4220,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4276,6 +4418,13 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4514,6 +4663,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dompurify": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
@@ -4572,6 +4728,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-toolkit": {
       "version": "1.45.1",
@@ -4790,6 +4953,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4805,6 +4978,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -5257,6 +5440,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -5635,9 +5828,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5659,9 +5849,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5683,9 +5870,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5707,9 +5891,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6697,6 +6878,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6772,6 +6963,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -6887,6 +7089,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -7295,6 +7504,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -7512,6 +7735,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -7542,6 +7772,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackblur-canvas": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
@@ -7551,6 +7788,13 @@
       "engines": {
         "node": ">=0.1.14"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -7564,6 +7808,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -7674,6 +7931,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7689,6 +7963,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -8139,6 +8423,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -8162,6 +8536,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/app/package.json
+++ b/app/package.json
@@ -8,6 +8,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e:dynamic": "bash test/e2e/dynamic-routes.sh",
     "test:e2e:links": "bash test/e2e/link-integrity.sh",
     "test:e2e:prod": "bash test/e2e/production-build.sh",
@@ -83,6 +85,7 @@
     "@eslint/js": "^9.39.4",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/jest-dom": "^6.9.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -97,6 +100,7 @@
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.2",
-    "vite": "^8.0.8"
+    "vite": "^8.0.8",
+    "vitest": "^4.1.5"
   }
 }

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,17 +1,58 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useState, useMemo, type ComponentType } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import NotFound from "./pages/NotFound";
 import DocsLayout from "./pages/DocsLayout";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
-const LandingPage = lazy(() => import("./pages/LandingPage"));
-const Index = lazy(() => import("./pages/Index"));
-const DocsHome = lazy(() => import("./pages/DocsHome"));
-const MarkdownPage = lazy(() => import("./pages/MarkdownPage"));
+/**
+ * Wraps a dynamic import so that chunk-load failures can be retried.
+ * React.lazy caches rejected imports, so ErrorBoundary "Try Again" would
+ * re-throw the cached failure. This helper uses a module-level counter as
+ * a key — when the ErrorBoundary resets, the counter increments, React
+ * unmounts the old lazy component and mounts a fresh one that re-attempts
+ * the import.
+ *
+ * Browsers cache failed dynamic imports by module specifier, so retrying
+ * with a fresh lazy() wrapper alone doesn't bypass the cache. After
+ * MAX_RETRIES failed attempts, we fall back to a full page reload, which
+ * fetches fresh HTML referencing fresh chunks — the same approach used by
+ * Next.js and other frameworks.
+ */
+const MAX_RETRIES = 2;
+
+const retryableLazy = <T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>
+) => {
+  let retryCount = 0;
+  const Component = (props: React.ComponentProps<T>) => {
+    const [count, setCount] = useState(retryCount);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- count is intentionally used to trigger lazy() recreation on retry
+    const LazyComp = useMemo(() => lazy(factory), [count]);
+    const handleReset = () => {
+      retryCount++;
+      if (retryCount > MAX_RETRIES) {
+        window.location.reload();
+        return;
+      }
+      setCount(retryCount);
+    };
+    return (
+      <ErrorBoundary onReset={handleReset} resetLabel="Try Again">
+        <LazyComp {...(props as Record<string, unknown>)} />
+      </ErrorBoundary>
+    );
+  };
+  return Component;
+};
+
+const LandingPage = retryableLazy(() => import("./pages/LandingPage"));
+const Index = retryableLazy(() => import("./pages/Index"));
+const DocsHome = retryableLazy(() => import("./pages/DocsHome"));
+const MarkdownPage = retryableLazy(() => import("./pages/MarkdownPage"));
 
 
 const queryClient = new QueryClient();
@@ -21,6 +62,22 @@ const LoadingSpinner = () => (
     <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
   </div>
 );
+
+const AppRoutes = () => {
+  const location = useLocation();
+  return (
+    <Routes>
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/questionnaire" element={<Index />} />
+      <Route path="/docs" element={<DocsLayout />}>
+        <Route index element={<DocsHome />} />
+        <Route path="*" element={<MarkdownPage key={location.pathname} />} />
+      </Route>
+      {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+      <Route path="*" element={<NotFound />} />
+    </Routes>
+  );
+};
 
 const App = () => {
   // Read router basename from environment, fall back to empty string
@@ -34,16 +91,7 @@ const App = () => {
         <ErrorBoundary>
           <BrowserRouter basename={basename}>
             <Suspense fallback={<LoadingSpinner />}>
-              <Routes>
-                <Route path="/" element={<LandingPage />} />
-                <Route path="/questionnaire" element={<Index />} />
-                <Route path="/docs" element={<DocsLayout />}>
-                  <Route index element={<DocsHome />} />
-                  <Route path="*" element={<ErrorBoundary><MarkdownPage /></ErrorBoundary>} />
-                </Route>
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
+              <AppRoutes />
             </Suspense>
           </BrowserRouter>
         </ErrorBoundary>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -9,6 +9,7 @@ import LandingPage from "./pages/LandingPage";
 import DocsLayout from "./pages/DocsLayout";
 import DocsHome from "./pages/DocsHome";
 import MarkdownPage from "./pages/MarkdownPage";
+import ErrorBoundary from "@/components/ErrorBoundary";
 
 
 const queryClient = new QueryClient();
@@ -22,19 +23,20 @@ const App = () => {
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter basename={basename}>
-          <Routes>
-            <Route path="/" element={<LandingPage />} />
-            <Route path="/questionnaire" element={<Index />} />
-            <Route path="/docs" element={<DocsLayout />}>
-              <Route index element={<DocsHome />} />
-
-              <Route path="*" element={<MarkdownPage />} />
-            </Route>
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </BrowserRouter>
+        <ErrorBoundary>
+          <BrowserRouter basename={basename}>
+            <Routes>
+              <Route path="/" element={<LandingPage />} />
+              <Route path="/questionnaire" element={<Index />} />
+              <Route path="/docs" element={<DocsLayout />}>
+                <Route index element={<DocsHome />} />
+                <Route path="*" element={<ErrorBoundary><MarkdownPage /></ErrorBoundary>} />
+              </Route>
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </BrowserRouter>
+        </ErrorBoundary>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,18 +1,26 @@
+import { lazy, Suspense } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
-import LandingPage from "./pages/LandingPage";
 import DocsLayout from "./pages/DocsLayout";
-import DocsHome from "./pages/DocsHome";
-import MarkdownPage from "./pages/MarkdownPage";
 import ErrorBoundary from "@/components/ErrorBoundary";
+
+const LandingPage = lazy(() => import("./pages/LandingPage"));
+const Index = lazy(() => import("./pages/Index"));
+const DocsHome = lazy(() => import("./pages/DocsHome"));
+const MarkdownPage = lazy(() => import("./pages/MarkdownPage"));
 
 
 const queryClient = new QueryClient();
+
+const LoadingSpinner = () => (
+  <div className="flex items-center justify-center min-h-screen">
+    <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+  </div>
+);
 
 const App = () => {
   // Read router basename from environment, fall back to empty string
@@ -25,16 +33,18 @@ const App = () => {
         <Sonner />
         <ErrorBoundary>
           <BrowserRouter basename={basename}>
-            <Routes>
-              <Route path="/" element={<LandingPage />} />
-              <Route path="/questionnaire" element={<Index />} />
-              <Route path="/docs" element={<DocsLayout />}>
-                <Route index element={<DocsHome />} />
-                <Route path="*" element={<ErrorBoundary><MarkdownPage /></ErrorBoundary>} />
-              </Route>
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <Suspense fallback={<LoadingSpinner />}>
+              <Routes>
+                <Route path="/" element={<LandingPage />} />
+                <Route path="/questionnaire" element={<Index />} />
+                <Route path="/docs" element={<DocsLayout />}>
+                  <Route index element={<DocsHome />} />
+                  <Route path="*" element={<ErrorBoundary><MarkdownPage /></ErrorBoundary>} />
+                </Route>
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
           </BrowserRouter>
         </ErrorBoundary>
       </TooltipProvider>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState, useMemo, type ComponentType } from "react";
+import { Suspense } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -7,53 +7,12 @@ import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import NotFound from "./pages/NotFound";
 import DocsLayout from "./pages/DocsLayout";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import { retryableLazy } from "@/lib/retryableLazy";
 
-/**
- * Wraps a dynamic import so that chunk-load failures can be retried.
- * React.lazy caches rejected imports, so ErrorBoundary "Try Again" would
- * re-throw the cached failure. This helper uses a module-level counter as
- * a key — when the ErrorBoundary resets, the counter increments, React
- * unmounts the old lazy component and mounts a fresh one that re-attempts
- * the import.
- *
- * Browsers cache failed dynamic imports by module specifier, so retrying
- * with a fresh lazy() wrapper alone doesn't bypass the cache. After
- * MAX_RETRIES failed attempts, we fall back to a full page reload, which
- * fetches fresh HTML referencing fresh chunks — the same approach used by
- * Next.js and other frameworks.
- */
-const MAX_RETRIES = 2;
-
-const retryableLazy = <T extends ComponentType<unknown>>(
-  factory: () => Promise<{ default: T }>
-) => {
-  let retryCount = 0;
-  const Component = (props: React.ComponentProps<T>) => {
-    const [count, setCount] = useState(retryCount);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- count is intentionally used to trigger lazy() recreation on retry
-    const LazyComp = useMemo(() => lazy(factory), [count]);
-    const handleReset = () => {
-      retryCount++;
-      if (retryCount > MAX_RETRIES) {
-        window.location.reload();
-        return;
-      }
-      setCount(retryCount);
-    };
-    return (
-      <ErrorBoundary onReset={handleReset} resetLabel="Try Again">
-        <LazyComp {...(props as Record<string, unknown>)} />
-      </ErrorBoundary>
-    );
-  };
-  return Component;
-};
-
-const LandingPage = retryableLazy(() => import("./pages/LandingPage"));
-const Index = retryableLazy(() => import("./pages/Index"));
-const DocsHome = retryableLazy(() => import("./pages/DocsHome"));
-const MarkdownPage = retryableLazy(() => import("./pages/MarkdownPage"));
-
+const LandingPage = retryableLazy(() => import("./pages/LandingPage"), { name: 'LandingPage' });
+const Index = retryableLazy(() => import("./pages/Index"), { name: 'Index' });
+const DocsHome = retryableLazy(() => import("./pages/DocsHome"), { name: 'DocsHome' });
+const MarkdownPage = retryableLazy(() => import("./pages/MarkdownPage"), { name: 'MarkdownPage' });
 
 const queryClient = new QueryClient();
 

--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -3,7 +3,13 @@ import { AlertTriangle } from 'lucide-react';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
-  fallback?: ReactNode;
+  /** Custom fallback UI. Can be a ReactNode, or a render function receiving resetErrorBoundary. */
+  fallback?: ReactNode | ((resetErrorBoundary: () => void) => ReactNode);
+  /** Called when the user clicks the reset button. Use this to reset parent state
+   *  (e.g. clear questionnaire answers) so the child tree re-renders with fresh props. */
+  onReset?: () => void;
+  /** Custom label for the reset button. Defaults to "Start Over" when onReset is set, "Try Again" otherwise. */
+  resetLabel?: string;
 }
 
 interface ErrorBoundaryState {
@@ -27,12 +33,18 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   resetErrorBoundary = (): void => {
     this.setState({ hasError: false, error: null });
+    this.props.onReset?.();
+  };
+
+  handleReload = (): void => {
+    window.location.reload();
   };
 
   render(): ReactNode {
     if (this.state.hasError) {
       if (this.props.fallback) {
-        return this.props.fallback;
+        const fallback = this.props.fallback;
+        return typeof fallback === 'function' ? fallback(this.resetErrorBoundary) : fallback;
       }
 
       return (
@@ -47,15 +59,25 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
               Something went wrong
             </h2>
             <p className="text-muted-foreground text-sm mb-6">
-              An unexpected error occurred. Your progress has been preserved.
-              Please try again.
+              {this.props.onReset
+                ? `An unexpected error occurred. Click "${this.props.resetLabel ?? 'Start Over'}" to reset, or reload the page.`
+                : 'An unexpected error occurred. Please try again or reload the page.'
+              }
             </p>
-            <button
-              onClick={this.resetErrorBoundary}
-              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
-            >
-              Try Again
-            </button>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <button
+                onClick={this.resetErrorBoundary}
+                className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                {this.props.resetLabel ?? (this.props.onReset ? 'Start Over' : 'Try Again')}
+              </button>
+              <button
+                onClick={this.handleReload}
+                className="inline-flex items-center justify-center rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+              >
+                Reload Page
+              </button>
+            </div>
           </div>
         </div>
       );

--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error('ErrorBoundary caught an error:', error, errorInfo);
+  }
+
+  resetErrorBoundary = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex items-center justify-center min-h-[300px] p-6">
+          <div className="bg-card border border-border rounded-xl shadow-sm max-w-md w-full p-8 text-center">
+            <div className="flex justify-center mb-4">
+              <div className="rounded-full bg-destructive/10 p-3">
+                <AlertTriangle className="h-8 w-8 text-destructive" />
+              </div>
+            </div>
+            <h2 className="text-xl font-semibold text-foreground mb-2">
+              Something went wrong
+            </h2>
+            <p className="text-muted-foreground text-sm mb-6">
+              An unexpected error occurred. Your progress has been preserved.
+              Please try again.
+            </p>
+            <button
+              onClick={this.resetErrorBoundary}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/app/src/components/ErrorBoundary.tsx
+++ b/app/src/components/ErrorBoundary.tsx
@@ -8,7 +8,11 @@ interface ErrorBoundaryProps {
   /** Called when the user clicks the reset button. Use this to reset parent state
    *  (e.g. clear questionnaire answers) so the child tree re-renders with fresh props. */
   onReset?: () => void;
-  /** Custom label for the reset button. Defaults to "Start Over" when onReset is set, "Try Again" otherwise. */
+  /** Alias for onReset. Used by retryableLazy and similar retry-oriented wrappers. */
+  onRetry?: () => void;
+  /** Called when an error is caught by the boundary. Receives the error object. */
+  onError?: (error: Error) => void;
+  /** Custom label for the reset button. Defaults to "Start Over" when onReset/onRetry is set, "Try Again" otherwise. */
   resetLabel?: string;
 }
 
@@ -29,11 +33,14 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     console.error('ErrorBoundary caught an error:', error, errorInfo);
+    this.props.onError?.(error);
   }
 
   resetErrorBoundary = (): void => {
     this.setState({ hasError: false, error: null });
-    this.props.onReset?.();
+    // onRetry takes precedence; fall back to onReset for backwards compatibility
+    const retry = this.props.onRetry ?? this.props.onReset;
+    retry?.();
   };
 
   handleReload = (): void => {
@@ -59,7 +66,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
               Something went wrong
             </h2>
             <p className="text-muted-foreground text-sm mb-6">
-              {this.props.onReset
+              {(this.props.onRetry ?? this.props.onReset)
                 ? `An unexpected error occurred. Click "${this.props.resetLabel ?? 'Start Over'}" to reset, or reload the page.`
                 : 'An unexpected error occurred. Please try again or reload the page.'
               }
@@ -69,7 +76,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
                 onClick={this.resetErrorBoundary}
                 className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
               >
-                {this.props.resetLabel ?? (this.props.onReset ? 'Start Over' : 'Try Again')}
+                {this.props.resetLabel ?? ((this.props.onRetry ?? this.props.onReset) ? 'Start Over' : 'Try Again')}
               </button>
               <button
                 onClick={this.handleReload}

--- a/app/src/components/PDFTemplate.tsx
+++ b/app/src/components/PDFTemplate.tsx
@@ -1,6 +1,7 @@
 import { useRef, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
+import { tArray } from '@/lib/i18n-helpers';
 import {
   Cpu,
   Zap,
@@ -176,7 +177,7 @@ const PDFTemplate = ({ recommendation, alternatives, answers }: PDFTemplateProps
           <div className="flex-1">
             <h4 className="font-medium mb-2 text-gray-800">{t('common.pros')}</h4>
             <ul className="space-y-1">
-              {t(`questionnaire.questions.results.devices.${topRecommendation.device.key}.pros`, { returnObjects: true }).map((pro: string, index: number) => (
+              {tArray(t, `questionnaire.questions.results.devices.${topRecommendation.device.key}.pros`).map((pro: string, index: number) => (
                 <li key={index} className="flex items-start gap-2">
                   <Check className="h-4 w-4 text-green-500 mt-1 shrink-0" />
                   <span className="text-gray-700">{pro}</span>
@@ -187,7 +188,7 @@ const PDFTemplate = ({ recommendation, alternatives, answers }: PDFTemplateProps
           <div className="flex-1">
             <h4 className="font-medium mb-2 text-gray-800">{t('common.cons')}</h4>
             <ul className="space-y-1">
-              {t(`questionnaire.questions.results.devices.${topRecommendation.device.key}.cons`, { returnObjects: true }).map((con: string, index: number) => (
+              {tArray(t, `questionnaire.questions.results.devices.${topRecommendation.device.key}.cons`).map((con: string, index: number) => (
                 <li key={index} className="flex items-start gap-2">
                   <span className="h-4 w-4 text-gray-400 mt-1 shrink-0">-</span>
                   <span className="text-gray-600">{con}</span>

--- a/app/src/components/Questionnaire.tsx
+++ b/app/src/components/Questionnaire.tsx
@@ -154,7 +154,7 @@ const Questionnaire = () => {
       );
     } else if (currentQuestion.id === 'results') {
       return (
-        <ErrorBoundary>
+        <ErrorBoundary resetLabel="Try Again">
           <RecommendationResults
             key="recommendation-results"
             answers={answers as UserAnswers}

--- a/app/src/components/Questionnaire.tsx
+++ b/app/src/components/Questionnaire.tsx
@@ -5,6 +5,7 @@ import QuestionCard from './QuestionCard';
 import PointsAllocation from './PointsAllocation';
 import UsageSelection from './UsageSelection';
 import RecommendationResults from './RecommendationResults';
+import ErrorBoundary from './ErrorBoundary';
 import { AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import type { PriorityAllocation, UsageSelectionValues, UserAnswers } from '@/types/questionnaire';
@@ -153,11 +154,13 @@ const Questionnaire = () => {
       );
     } else if (currentQuestion.id === 'results') {
       return (
-        <RecommendationResults
-          key="recommendation-results"
-          answers={answers as UserAnswers}
-          onStartOver={handleStartOver}
-        />
+        <ErrorBoundary>
+          <RecommendationResults
+            key="recommendation-results"
+            answers={answers as UserAnswers}
+            onStartOver={handleStartOver}
+          />
+        </ErrorBoundary>
       );
     } else {
       return (

--- a/app/src/components/Questionnaire.tsx
+++ b/app/src/components/Questionnaire.tsx
@@ -1,4 +1,5 @@
 
+import { useEffect } from 'react';
 import { useQuestionnaire } from '@/context/QuestionnaireContext';
 import ProgressBar from './ProgressBar';
 import QuestionCard from './QuestionCard';
@@ -12,10 +13,8 @@ import type { PriorityAllocation, UsageSelectionValues, UserAnswers } from '@/ty
 
 const Questionnaire = () => {
   const { t } = useTranslation();
-  const { currentStep, setCurrentStep, answers, setAnswer, goBack, resetSurvey } = useQuestionnaire();
+  const { currentStep, setCurrentStep, answers, setAnswer, goBack, resetSurvey, setTotalSteps } = useQuestionnaire();
 
-  // NOTE: The number of steps here must match `totalSteps` in QuestionnaireContext.tsx.
-  // If you add or remove a step, update `totalSteps` there.
   const questions = [
     {
       id: 'electricity',
@@ -104,6 +103,11 @@ const Questionnaire = () => {
     },
   ];
 
+  // Keep totalSteps in sync with the questions array
+  useEffect(() => {
+    setTotalSteps(questions.length);
+  }, [questions.length, setTotalSteps]);
+
   const handleNext = () => {
     if (currentStep < questions.length - 1) {
       setCurrentStep(currentStep + 1);
@@ -156,7 +160,7 @@ const Questionnaire = () => {
       );
     } else if (currentQuestion.id === 'results') {
       return (
-        <ErrorBoundary resetLabel={t('errors.tryAgain')}>
+        <ErrorBoundary resetLabel={t('errors.tryAgain')} onReset={resetSurvey}>
           <RecommendationResults
             key="recommendation-results"
             answers={answers as UserAnswers}

--- a/app/src/components/Questionnaire.tsx
+++ b/app/src/components/Questionnaire.tsx
@@ -14,6 +14,8 @@ const Questionnaire = () => {
   const { t } = useTranslation();
   const { currentStep, setCurrentStep, answers, setAnswer, goBack, resetSurvey } = useQuestionnaire();
 
+  // NOTE: The number of steps here must match `totalSteps` in QuestionnaireContext.tsx.
+  // If you add or remove a step, update `totalSteps` there.
   const questions = [
     {
       id: 'electricity',

--- a/app/src/components/Questionnaire.tsx
+++ b/app/src/components/Questionnaire.tsx
@@ -156,7 +156,7 @@ const Questionnaire = () => {
       );
     } else if (currentQuestion.id === 'results') {
       return (
-        <ErrorBoundary resetLabel="Try Again">
+        <ErrorBoundary resetLabel={t('errors.tryAgain')}>
           <RecommendationResults
             key="recommendation-results"
             answers={answers as UserAnswers}

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { tArray } from '@/lib/i18n-helpers';
 import { cn } from '@/lib/utils';
 import {
   Cpu,
@@ -612,7 +613,7 @@ const RecommendationResults = ({
                       <div className="flex-1">
                         <h4 className="font-medium mb-2">{t('questionnaire.questions.results.pros')}</h4>
                         <ul className="space-y-1">
-                          {(t(`questionnaire.questions.results.devices.${topRecommendation.device.key}.pros`, { returnObjects: true }) as string[]).map((pro: string, index: number) => (
+                          {tArray(t, `questionnaire.questions.results.devices.${topRecommendation.device.key}.pros`).map((pro: string, index: number) => (
                             <li key={index} className="flex items-start gap-2">
                               <Check className="h-4 w-4 text-green-500 mt-1 shrink-0" />
                               <span>{pro}</span>
@@ -623,7 +624,7 @@ const RecommendationResults = ({
                       <div className="flex-1">
                         <h4 className="font-medium mb-2">{t('questionnaire.questions.results.cons')}</h4>
                         <ul className="space-y-1">
-                          {(t(`questionnaire.questions.results.devices.${topRecommendation.device.key}.cons`, { returnObjects: true }) as string[]).map((con: string, index: number) => (
+                          {tArray(t, `questionnaire.questions.results.devices.${topRecommendation.device.key}.cons`).map((con: string, index: number) => (
                             <li key={index} className="flex items-start gap-2 text-muted-foreground">
                               <span className="h-4 w-4 text-muted-foreground mt-1 shrink-0">-</span>
                               <span>{con}</span>
@@ -733,7 +734,7 @@ const RecommendationResults = ({
                                   <div>
                                     <h4 className="text-sm font-medium mb-1">{t('questionnaire.questions.results.pros')}</h4>
                                     <ul className="text-sm space-y-1">
-                                      {(t(`questionnaire.questions.results.devices.${alternative.device.key}.pros`, { returnObjects: true }) as string[]).map((pro: string, i: number) => (
+                                      {tArray(t, `questionnaire.questions.results.devices.${alternative.device.key}.pros`).map((pro: string, i: number) => (
                                         <li key={i} className="flex items-start gap-1">
                                           <Check className="h-3 w-3 text-green-500 mt-1 shrink-0" />
                                           <span>{pro}</span>
@@ -744,7 +745,7 @@ const RecommendationResults = ({
                                   <div>
                                     <h4 className="text-sm font-medium mb-1">{t('questionnaire.questions.results.cons')}</h4>
                                     <ul className="text-sm space-y-1 text-muted-foreground">
-                                      {(t(`questionnaire.questions.results.devices.${alternative.device.key}.cons`, { returnObjects: true }) as string[]).map((con: string, i: number) => (
+                                      {tArray(t, `questionnaire.questions.results.devices.${alternative.device.key}.cons`).map((con: string, i: number) => (
                                         <li key={i} className="flex items-start gap-1">
                                           <span className="h-3 w-3 mt-1 shrink-0">-</span>
                                           <span>{con}</span>

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -161,7 +161,7 @@ const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number
 
   return {
     energy: energyMap[answers.electricity] || 3,
-    concurrency: concurrencyMap[answers.users] || 3,
+    concurrency: concurrencyMap[answers.users ?? '1-2'] || 3,
     growth: growthMap[answers.growth] || 3,
     reusable: reusableMap[answers.reuse] || 0,
     formatEase: formatEaseMap[answers.format] || 3,
@@ -178,8 +178,16 @@ const calculateDeviceScores = (
 
   // Get point weights from user's point allocation
   // Mapping: easyToUse→formatEase, lowPower→energy, scalable→growth, lowCost→cost
-  // language is excluded (no corresponding hardware attribute; weight redistributes via normalization)
-  // concurrency and reusable are not driven by priorities (driven by `users` answer and `reuse` special case)
+  // language is excluded from device scoring (no corresponding hardware attribute).
+  // Its points are redistributed proportionally among the other 4 priority-driven attributes.
+  // concurrency is driven by the `users` answer, not by priorities — it gets a baseline weight
+  // proportional to the user's concurrency needs so that multi-user scenarios influence rankings.
+  // reusable is driven by the `reuse` answer special case below, not by priorities.
+
+  const languagePoints = points.language ?? 0;
+  const priorityKeys: AttributeKey[] = ['energy', 'growth', 'formatEase', 'cost'];
+
+  // Start with direct priority allocations
   const pointWeights: Record<AttributeKey, number> = {
     energy: points.lowPower ?? 0,
     concurrency: 0,
@@ -188,6 +196,35 @@ const calculateDeviceScores = (
     formatEase: points.easyToUse ?? 0,
     cost: points.lowCost ?? 0
   };
+
+  // Redistribute language points proportionally among the 4 priority-driven attributes
+  if (languagePoints > 0) {
+    const totalPriorityPoints = priorityKeys.reduce((sum, key) => sum + pointWeights[key], 0);
+    if (totalPriorityPoints > 0) {
+      // Distribute proportionally to existing allocations
+      priorityKeys.forEach(key => {
+        pointWeights[key] += languagePoints * (pointWeights[key] / totalPriorityPoints);
+      });
+    } else {
+      // All priorities were 0 — distribute equally
+      const share = languagePoints / priorityKeys.length;
+      priorityKeys.forEach(key => {
+        pointWeights[key] = share;
+      });
+    }
+  }
+
+  // Derive concurrency baseline weight from the `users` answer
+  // More users → higher concurrency weight so multi-user needs influence device ranking
+  const concurrencyMap: Record<string, number> = {
+    '1-2': 0.5,   // Low concurrency need — small baseline weight
+    '3-5': 1.5,   // Moderate — meaningful weight
+    '6+': 3,      // High — strong influence on ranking
+  };
+  const rawUsers = answers.users ?? '1-2';
+  pointWeights.concurrency = priorityKeys.some(key => pointWeights[key] > 0)
+    ? (concurrencyMap[rawUsers] ?? 0.5)
+    : 0;
 
   // Calculate total points allocated
   const totalPoints = Object.values(pointWeights).reduce((sum, points) => sum + points, 0);

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -250,8 +250,9 @@ const calculateDeviceScores = (
     });
 
     // Calculate match percentage (0-100%)
-    const maxPossibleWeightedScore = 5; // Max similarity (5) for all attributes
-    const matchPercentage = (totalScore / maxPossibleWeightedScore) * 100;
+    // Max possible score is 5 (perfect similarity) weighted by actual weights
+    const maxPossibleWeightedScore = 5 * Object.values(normalizedWeights).reduce((sum, w) => sum + w, 0);
+    const matchPercentage = maxPossibleWeightedScore > 0 ? (totalScore / maxPossibleWeightedScore) * 100 : 0;
 
     return {
       device,

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -176,12 +176,15 @@ const calculateDeviceScores = (
   const points: PriorityAllocation = answers.points ?? {};
 
   // Get point weights from user's point allocation
+  // Mapping: easyToUse→formatEase, lowPower→energy, scalable→growth, lowCost→cost
+  // language is excluded (no corresponding hardware attribute; weight redistributes via normalization)
+  // concurrency and reusable are not driven by priorities (driven by `users` answer and `reuse` special case)
   const pointWeights: Record<AttributeKey, number> = {
-    energy: points.easyToUse ?? 0,
-    concurrency: points.lowPower ?? 0,
-    growth: points.language ?? 0,
-    reusable: points.scalable ?? 0,
-    formatEase: points.lowCost ?? 0,
+    energy: points.lowPower ?? 0,
+    concurrency: 0,
+    growth: points.scalable ?? 0,
+    reusable: 0,
+    formatEase: points.easyToUse ?? 0,
     cost: points.lowCost ?? 0
   };
 

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -223,14 +223,14 @@ export const calculateDeviceScores = (
 
   // Derive concurrency baseline weight from the `users` answer
   // More users → higher concurrency weight so multi-user needs influence device ranking
-  const concurrencyWeightMap: Record<string, number> = {
+  const concurrencyBaselineWeight: Record<string, number> = {
     '1-2': 0.5,   // Low concurrency need — small baseline weight
     '3-5': 1.5,   // Moderate — meaningful weight
     '6+': 3,      // High — strong influence on ranking
   };
   const rawUsers = answers.users ?? '1-2';
   pointWeights.concurrency = priorityKeys.some(key => pointWeights[key] > 0)
-    ? (concurrencyWeightMap[rawUsers] ?? 0.5)
+    ? (concurrencyBaselineWeight[rawUsers] ?? 0.5)
     : 0;
 
   // Calculate total points allocated
@@ -255,14 +255,23 @@ export const calculateDeviceScores = (
   if (answers.reuse === 'yes') {
     normalizedWeights.reusable = 0.4; // 40% weight to reusability
 
-    // Redistribute remaining 60% among other attributes
-    const remainingWeight = 0.6;
-    const otherAttributes = Object.keys(normalizedWeights).filter(key => key !== 'reusable');
-    const weightPerAttribute = remainingWeight / otherAttributes.length;
+    // Redistribute remaining 60% proportionally among other attributes,
+    // preserving derived weights (e.g. concurrency from the `users` answer)
+    const otherAttributes = Object.keys(normalizedWeights).filter(key => key !== 'reusable') as AttributeKey[];
+    const otherTotal = otherAttributes.reduce((sum, key) => sum + normalizedWeights[key], 0);
 
-    otherAttributes.forEach(key => {
-      normalizedWeights[key as AttributeKey] = weightPerAttribute;
-    });
+    if (otherTotal > 0) {
+      // Scale existing proportions to fill the remaining 60%
+      otherAttributes.forEach(key => {
+        normalizedWeights[key] = 0.6 * (normalizedWeights[key] / otherTotal);
+      });
+    } else {
+      // Fallback: equal distribution if all weights were zero
+      const weightPerAttribute = 0.6 / otherAttributes.length;
+      otherAttributes.forEach(key => {
+        normalizedWeights[key] = weightPerAttribute;
+      });
+    }
   }
 
   // Calculate scores for each device

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -119,10 +119,13 @@ const attributeIcons: Record<AttributeKey, ReactNode> = {
 // Function to normalize user answers to the 1-5 scale
 export const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number> => {
   // Map electricity answer to energy score (1-5)
+  // Higher value = greater need for energy efficiency.
+  // The similarity formula (5 - |user - device|) matches user needs to device capabilities,
+  // so a user with frequent outages (high need) gets a high value, matching efficient devices.
   const energyMap: Record<string, number> = {
-    'yes': 5, // Reliable power -> can use any device
-    'sometimes': 3, // Unreliable -> prefer energy efficient
-    'no': 1 // Frequent outages -> need very energy efficient
+    'yes': 1, // Reliable power → low need for efficiency
+    'sometimes': 3, // Unreliable → moderate need for efficiency
+    'no': 5 // Frequent outages → high need for efficiency
   };
 
   // Map users answer to concurrency score (1-5)
@@ -146,10 +149,14 @@ export const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey,
   };
 
   // Map format answer to formatEase score (1-5)
+  // Higher value = greater need for easy setup.
+  // The similarity formula (5 - |user - device|) matches user needs to device capabilities,
+  // so a user who cannot format (high need for easy setup) gets a high value,
+  // matching devices that are easier to set up.
   const formatEaseMap: Record<string, number> = {
-    'yes': 5, // Can format confidently -> high setup ease
-    'maybe': 3, // With guidance -> moderate setup ease
-    'no': 1 // Cannot format -> low setup ease
+    'yes': 1, // Can format confidently → low need for easy setup
+    'maybe': 3, // With guidance → moderate need for easy setup
+    'no': 5 // Cannot format → high need for easy setup
   };
 
   // Map price answer to cost score (1-5)

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -59,7 +59,7 @@ import nucImage from '../assets/nuc.png';
 import reusedPCImage from '../assets/laptop.jpg'; // Using banner as placeholder for reused PC
 
 // Define the devices with their attributes
-const devices: DeviceAttributes[] = [
+export const devices: DeviceAttributes[] = [
   {
     key: 'raspberryPi',
     name: 'Raspberry Pi',
@@ -117,7 +117,7 @@ const attributeIcons: Record<AttributeKey, ReactNode> = {
 };
 
 // Function to normalize user answers to the 1-5 scale
-const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number> => {
+export const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number> => {
   // Map electricity answer to energy score (1-5)
   const energyMap: Record<string, number> = {
     'yes': 5, // Reliable power -> can use any device
@@ -170,7 +170,7 @@ const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number
 };
 
 // Function to calculate device scores based on user answers and point allocation
-const calculateDeviceScores = (
+export const calculateDeviceScores = (
   answers: UserAnswers,
   normalizedAnswers: Record<AttributeKey, number>
 ): DeviceScore[] => {
@@ -216,14 +216,14 @@ const calculateDeviceScores = (
 
   // Derive concurrency baseline weight from the `users` answer
   // More users → higher concurrency weight so multi-user needs influence device ranking
-  const concurrencyMap: Record<string, number> = {
+  const concurrencyWeightMap: Record<string, number> = {
     '1-2': 0.5,   // Low concurrency need — small baseline weight
     '3-5': 1.5,   // Moderate — meaningful weight
     '6+': 3,      // High — strong influence on ranking
   };
   const rawUsers = answers.users ?? '1-2';
   pointWeights.concurrency = priorityKeys.some(key => pointWeights[key] > 0)
-    ? (concurrencyMap[rawUsers] ?? 0.5)
+    ? (concurrencyWeightMap[rawUsers] ?? 0.5)
     : 0;
 
   // Calculate total points allocated

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -30,7 +30,6 @@ import {
   Mail,
   MessageCircle,
   AlertCircle,
-  Cloud,
   HardDrive,
   Settings,
   Package,
@@ -41,70 +40,15 @@ import { downloadPDF, sharePDF } from '@/utils/pdfGenerator';
 import PDFTemplate from './PDFTemplate';
 import { copyUrlToClipboard, shareUrl } from '@/utils/statePersistence';
 import { getRecommendations } from '@/utils/recommendations';
+import { normalizeUserAnswers, calculateDeviceScores } from '@/utils/deviceScoring';
 import type {
   AttributeKey,
-  DeviceAttributes,
   DeviceKey,
   DeviceScore,
-  PriorityAllocation,
   UserAnswers,
   ServiceSuggestion,
   OSSuggestion,
 } from '@/types/questionnaire';
-
-// Import board images
-import raspberryPiImage from '../assets/pi.png';
-import zimaImage from '../assets/zima.png';
-import nucImage from '../assets/nuc.png';
-import reusedPCImage from '../assets/laptop.jpg'; // Using banner as placeholder for reused PC
-
-// Define the devices with their attributes
-export const devices: DeviceAttributes[] = [
-  {
-    key: 'raspberryPi',
-    name: 'Raspberry Pi',
-    energy: 5, // Very energy efficient
-    concurrency: 1, // Poor for multiple users
-    growth: 2, // Limited growth potential
-    reusable: 0, // Not reusable (new hardware)
-    formatEase: 3, // Moderate setup difficulty
-    cost: 5, // Very low cost
-    icon: <img src={raspberryPiImage} alt="Raspberry Pi" className="h-full w-full object-cover" />
-  },
-  {
-    key: 'zimaBoard',
-    name: 'ZimaBoard',
-    energy: 4, // Good energy efficiency
-    concurrency: 3, // Moderate multi-user support
-    growth: 3, // Moderate growth potential
-    reusable: 0, // Not reusable (new hardware)
-    formatEase: 2, // More difficult to set up
-    cost: 3, // Moderate cost
-    icon: <img src={zimaImage} alt="ZimaBoard" className="h-full w-full object-cover" />
-  },
-  {
-    key: 'intelNUC',
-    name: 'Intel NUC',
-    energy: 2, // Higher power consumption
-    concurrency: 5, // Excellent for multiple users
-    growth: 5, // Excellent growth potential
-    reusable: 0, // Not reusable (new hardware)
-    formatEase: 3, // Moderate setup difficulty
-    cost: 1, // High cost
-    icon: <img src={nucImage} alt="Intel NUC" className="h-full w-full object-cover" />
-  },
-  {
-    key: 'reusedPC',
-    name: 'Reused PC',
-    energy: 1, // High power consumption
-    concurrency: 4, // Good for multiple users
-    growth: 4, // Good growth potential
-    reusable: 5, // Excellent reusability (existing hardware)
-    formatEase: 2, // More difficult to set up
-    cost: 4, // Low cost (reused)
-    icon: <img src={reusedPCImage} alt="Recycled laptop" className="h-full w-full object-cover" />
-  }
-];
 
 // Map attribute keys to icons
 const attributeIcons: Record<AttributeKey, ReactNode> = {
@@ -114,208 +58,6 @@ const attributeIcons: Record<AttributeKey, ReactNode> = {
   reusable: <Recycle className="h-5 w-5" />,
   formatEase: <WrenchIcon className="h-5 w-5" />,
   cost: <DollarSign className="h-5 w-5" />
-};
-
-// Function to normalize user answers to the 1-5 scale
-export const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number> => {
-  // Map electricity answer to energy score (1-5)
-  // Higher value = greater need for energy efficiency.
-  // The similarity formula (5 - |user - device|) matches user needs to device capabilities,
-  // so a user with frequent outages (high need) gets a high value, matching efficient devices.
-  const energyMap: Record<string, number> = {
-    'yes': 1, // Reliable power → low need for efficiency
-    'sometimes': 3, // Unreliable → moderate need for efficiency
-    'no': 5 // Frequent outages → high need for efficiency
-  };
-
-  // Map users answer to concurrency score (1-5)
-  const concurrencyMap: Record<string, number> = {
-    '1-2': 1, // Few users -> low concurrency needs
-    '3-5': 3, // Medium users -> moderate concurrency needs
-    '6+': 5 // Many users -> high concurrency needs
-  };
-
-  // Map growth answer to growth score (1-5)
-  const growthMap: Record<string, number> = {
-    'low': 1, // Minimal growth -> low growth needs
-    'medium': 3, // Moderate growth -> moderate growth needs
-    'high': 5 // Rapid growth -> high growth needs
-  };
-
-  // Map reuse answer to reusable score (0 or 5)
-  const reusableMap: Record<string, number> = {
-    'yes': 5, // Has computer for reuse -> high reusability
-    'no': 0 // No computer for reuse -> no reusability
-  };
-
-  // Map format answer to formatEase score (1-5)
-  // Higher value = greater need for easy setup.
-  // The similarity formula (5 - |user - device|) matches user needs to device capabilities,
-  // so a user who cannot format (high need for easy setup) gets a high value,
-  // matching devices that are easier to set up.
-  const formatEaseMap: Record<string, number> = {
-    'yes': 1, // Can format confidently → low need for easy setup
-    'maybe': 3, // With guidance → moderate need for easy setup
-    'no': 5 // Cannot format → high need for easy setup
-  };
-
-  // Map price answer to cost score (1-5)
-  const costMap: Record<string, number> = {
-    'low': 5, // Low budget -> need low cost
-    'medium': 3, // Medium budget -> moderate cost acceptable
-    'high': 1 // High budget -> cost less important
-  };
-
-  return {
-    energy: energyMap[answers.electricity] || 3,
-    concurrency: concurrencyMap[answers.users ?? '1-2'] || 3,
-    growth: growthMap[answers.growth] || 3,
-    reusable: reusableMap[answers.reuse] || 0,
-    formatEase: formatEaseMap[answers.format] || 3,
-    cost: costMap[answers.price] || 3
-  };
-};
-
-// Function to calculate device scores based on user answers and point allocation
-export const calculateDeviceScores = (
-  answers: UserAnswers,
-  normalizedAnswers: Record<AttributeKey, number>
-): DeviceScore[] => {
-  const points: PriorityAllocation = answers.points ?? {};
-
-  // Get point weights from user's point allocation
-  // Mapping: easyToUse→formatEase, lowPower→energy, scalable→growth, lowCost→cost
-  // language is excluded from device scoring (no corresponding hardware attribute).
-  // Its points are redistributed proportionally among the other 4 priority-driven attributes.
-  // concurrency is driven by the `users` answer, not by priorities — it gets a baseline weight
-  // proportional to the user's concurrency needs so that multi-user scenarios influence rankings.
-  // reusable is driven by the `reuse` answer special case below, not by priorities.
-
-  const languagePoints = points.language ?? 0;
-  const priorityKeys: AttributeKey[] = ['energy', 'growth', 'formatEase', 'cost'];
-
-  // Start with direct priority allocations
-  const pointWeights: Record<AttributeKey, number> = {
-    energy: points.lowPower ?? 0,
-    concurrency: 0,
-    growth: points.scalable ?? 0,
-    reusable: 0,
-    formatEase: points.easyToUse ?? 0,
-    cost: points.lowCost ?? 0
-  };
-
-  // Redistribute language points proportionally among the 4 priority-driven attributes
-  if (languagePoints > 0) {
-    const totalPriorityPoints = priorityKeys.reduce((sum, key) => sum + pointWeights[key], 0);
-    if (totalPriorityPoints > 0) {
-      // Distribute proportionally to existing allocations
-      priorityKeys.forEach(key => {
-        pointWeights[key] += languagePoints * (pointWeights[key] / totalPriorityPoints);
-      });
-    } else {
-      // All priorities were 0 — distribute equally
-      const share = languagePoints / priorityKeys.length;
-      priorityKeys.forEach(key => {
-        pointWeights[key] = share;
-      });
-    }
-  }
-
-  // Derive concurrency baseline weight from the `users` answer
-  // More users → higher concurrency weight so multi-user needs influence device ranking
-  const concurrencyBaselineWeight: Record<string, number> = {
-    '1-2': 0.5,   // Low concurrency need — small baseline weight
-    '3-5': 1.5,   // Moderate — meaningful weight
-    '6+': 3,      // High — strong influence on ranking
-  };
-  const rawUsers = answers.users ?? '1-2';
-  // User allocated at least one priority point (any priority or language)
-  const userAllocatedPoints = Object.values(points).some(p => p > 0);
-  pointWeights.concurrency = userAllocatedPoints
-    ? (concurrencyBaselineWeight[rawUsers] ?? 0.5)
-    : 0;
-
-  // Calculate total points allocated
-  const totalPoints = Object.values(pointWeights).reduce((sum, points) => sum + points, 0);
-
-  // Calculate normalized weights (ensure sum is 1.0)
-  const normalizedWeights: Record<AttributeKey, number> = {} as Record<AttributeKey, number>;
-
-  if (totalPoints > 0) {
-    Object.keys(pointWeights).forEach(key => {
-      normalizedWeights[key as AttributeKey] = pointWeights[key as AttributeKey] / totalPoints;
-    });
-  } else {
-    // If no points allocated, use equal weights
-    const equalWeight = 1 / Object.keys(pointWeights).length;
-    Object.keys(pointWeights).forEach(key => {
-      normalizedWeights[key as AttributeKey] = equalWeight;
-    });
-  }
-
-  // Special case: if user has a computer for reuse, heavily weight the reusable attribute
-  if (answers.reuse === 'yes') {
-    normalizedWeights.reusable = 0.4; // 40% weight to reusability
-
-    // Redistribute remaining 60% proportionally among other attributes,
-    // preserving derived weights (e.g. concurrency from the `users` answer)
-    const otherAttributes = Object.keys(normalizedWeights).filter(key => key !== 'reusable') as AttributeKey[];
-    const otherTotal = otherAttributes.reduce((sum, key) => sum + normalizedWeights[key], 0);
-
-    if (otherTotal > 0) {
-      // Scale existing proportions to fill the remaining 60%
-      otherAttributes.forEach(key => {
-        normalizedWeights[key] = 0.6 * (normalizedWeights[key] / otherTotal);
-      });
-    } else {
-      // Fallback: equal distribution if all weights were zero
-      const weightPerAttribute = 0.6 / otherAttributes.length;
-      otherAttributes.forEach(key => {
-        normalizedWeights[key] = weightPerAttribute;
-      });
-    }
-  }
-
-  // Calculate scores for each device
-  return devices.map(device => {
-    // Calculate weighted score for each attribute
-    let totalScore = 0;
-    const maxPossibleScore = 5; // Maximum score per attribute
-    const strengths: AttributeKey[] = [];
-
-    Object.keys(normalizedAnswers).forEach(key => {
-      const attributeKey = key as AttributeKey;
-      const userValue = normalizedAnswers[attributeKey];
-      const deviceValue = device[attributeKey];
-
-      // Calculate similarity (5 - absolute difference)
-      // Higher similarity means better match
-      const similarity = 5 - Math.abs(userValue - deviceValue);
-
-      // Apply weight to similarity
-      const weightedSimilarity = similarity * normalizedWeights[attributeKey];
-
-      // Add to total score
-      totalScore += weightedSimilarity;
-
-      // If this is a strength (similarity >= 4), add to strengths array
-      if (similarity >= 4) {
-        strengths.push(attributeKey);
-      }
-    });
-
-    // Calculate match percentage (0-100%)
-    // Max possible score is 5 (perfect similarity) weighted by actual weights
-    const maxPossibleWeightedScore = 5 * Object.values(normalizedWeights).reduce((sum, w) => sum + w, 0);
-    const matchPercentage = maxPossibleWeightedScore > 0 ? (totalScore / maxPossibleWeightedScore) * 100 : 0;
-
-    return {
-      device,
-      score: totalScore,
-      matchPercentage: Math.round(matchPercentage),
-      strengths
-    };
-  }).sort((a, b) => b.score - a.score); // Sort by score (highest first)
 };
 
 // Function to get match rating text based on percentage

--- a/app/src/components/RecommendationResults.tsx
+++ b/app/src/components/RecommendationResults.tsx
@@ -229,7 +229,9 @@ export const calculateDeviceScores = (
     '6+': 3,      // High — strong influence on ranking
   };
   const rawUsers = answers.users ?? '1-2';
-  pointWeights.concurrency = priorityKeys.some(key => pointWeights[key] > 0)
+  // User allocated at least one priority point (any priority or language)
+  const userAllocatedPoints = Object.values(points).some(p => p > 0);
+  pointWeights.concurrency = userAllocatedPoints
     ? (concurrencyBaselineWeight[rawUsers] ?? 0.5)
     : 0;
 

--- a/app/src/context/QuestionnaireContext.tsx
+++ b/app/src/context/QuestionnaireContext.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   type SurveyState,
@@ -47,8 +47,14 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
 
   const totalSteps = 10; // 6 questions + points + usage + main use + results
 
+  const skipUrlUpdateRef = useRef(false);
+
   // Save state to localStorage and update URL whenever state changes
   useEffect(() => {
+    if (skipUrlUpdateRef.current) {
+      skipUrlUpdateRef.current = false;
+      return;
+    }
     const state: SurveyState = {
       currentStep,
       answers
@@ -70,6 +76,8 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
 
   // Reset the survey state
   const resetSurvey = () => {
+    skipUrlUpdateRef.current = true;
+
     // Clear URL parameters
     window.history.replaceState({}, '', window.location.pathname);
 
@@ -81,6 +89,13 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
 
     // Clear localStorage
     clearStoredState();
+
+    // Safety net: if React bails out of re-rendering because state is already
+    // at initial values (e.g. currentStep=0, answers={}), the effect that
+    // consumes skipUrlUpdateRef never fires and the ref stays stuck at true.
+    // Reset it after the current macrotask so the next legitimate step-advance
+    // correctly updates the URL.
+    setTimeout(() => { skipUrlUpdateRef.current = false; }, 0);
   };
 
   return (

--- a/app/src/context/QuestionnaireContext.tsx
+++ b/app/src/context/QuestionnaireContext.tsx
@@ -45,7 +45,9 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
   const [currentStep, setCurrentStep] = useState(initialState.currentStep);
   const [answers, setAnswers] = useState<Record<string, unknown>>(initialState.answers);
 
-  const totalSteps = 10; // 6 questions + points + usage + main use + results
+  // NOTE: Must match the number of question steps defined in Questionnaire.tsx.
+  // If you add or remove a step in the questionnaire, update this value.
+  const totalSteps = 10;
 
   const skipUrlUpdateRef = useRef(false);
 

--- a/app/src/context/QuestionnaireContext.tsx
+++ b/app/src/context/QuestionnaireContext.tsx
@@ -36,6 +36,7 @@ interface QuestionnaireContextType {
   setAnswer: (questionId: string, answer: unknown) => void;
   goBack: () => void;
   resetSurvey: () => void;
+  setTotalSteps: (total: number) => void;
 }
 
 const QuestionnaireContext = createContext<QuestionnaireContextType | undefined>(undefined);
@@ -45,9 +46,7 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
   const [currentStep, setCurrentStep] = useState(initialState.currentStep);
   const [answers, setAnswers] = useState<Record<string, unknown>>(initialState.answers);
 
-  // NOTE: Must match the number of question steps defined in Questionnaire.tsx.
-  // If you add or remove a step in the questionnaire, update this value.
-  const totalSteps = 10;
+  const [totalSteps, setTotalSteps] = useState(10);
 
   const skipUrlUpdateRef = useRef(false);
 
@@ -103,6 +102,7 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
         setAnswer,
         goBack,
         resetSurvey,
+        setTotalSteps,
       }}
     >
       {children}

--- a/app/src/context/QuestionnaireContext.tsx
+++ b/app/src/context/QuestionnaireContext.tsx
@@ -91,13 +91,6 @@ export function QuestionnaireProvider({ children }: { children: React.ReactNode 
 
     // Clear localStorage
     clearStoredState();
-
-    // Safety net: if React bails out of re-rendering because state is already
-    // at initial values (e.g. currentStep=0, answers={}), the effect that
-    // consumes skipUrlUpdateRef never fires and the ref stays stuck at true.
-    // Reset it after the current macrotask so the next legitimate step-advance
-    // correctly updates the URL.
-    setTimeout(() => { skipUrlUpdateRef.current = false; }, 0);
   };
 
   return (

--- a/app/src/i18n/locales/en.json
+++ b/app/src/i18n/locales/en.json
@@ -303,7 +303,8 @@
     "returnHome": "Return to Home"
   },
   "errors": {
-    "contextError": "useQuestionnaire must be used within a QuestionnaireProvider"
+    "contextError": "useQuestionnaire must be used within a QuestionnaireProvider",
+    "tryAgain": "Try Again"
   },
   "language": {
     "select": "Language",

--- a/app/src/i18n/locales/es.json
+++ b/app/src/i18n/locales/es.json
@@ -303,7 +303,8 @@
     "returnHome": "Volver a Inicio"
   },
   "errors": {
-    "contextError": "useQuestionnaire debe usarse dentro de un QuestionnaireProvider"
+    "contextError": "useQuestionnaire debe usarse dentro de un QuestionnaireProvider",
+    "tryAgain": "Intentar de Nuevo"
   },
   "language": {
     "select": "Idioma",

--- a/app/src/i18n/locales/pt.json
+++ b/app/src/i18n/locales/pt.json
@@ -303,7 +303,8 @@
     "returnHome": "Voltar para a Home"
   },
   "errors": {
-    "contextError": "useQuestionnaire deve ser usado dentro de um QuestionnaireProvider"
+    "contextError": "useQuestionnaire deve ser usado dentro de um QuestionnaireProvider",
+    "tryAgain": "Tentar Novamente"
   },
   "language": {
     "select": "Idioma",

--- a/app/src/lib/i18n-helpers.ts
+++ b/app/src/lib/i18n-helpers.ts
@@ -1,0 +1,12 @@
+import type { TFunction } from 'i18next';
+
+/**
+ * Safely call t() with returnObjects: true and return a string array.
+ * When a translation key is missing, i18next returns the key string itself.
+ * Calling .map() on a string iterates over individual characters, so we guard
+ * with Array.isArray() and return an empty array for non-array results.
+ */
+export function tArray(t: TFunction, key: string): string[] {
+  const result = t(key, { returnObjects: true });
+  return Array.isArray(result) ? result : [];
+}

--- a/app/src/lib/i18n-helpers.ts
+++ b/app/src/lib/i18n-helpers.ts
@@ -8,5 +8,11 @@ import type { TFunction } from 'i18next';
  */
 export function tArray(t: TFunction, key: string): string[] {
   const result = t(key, { returnObjects: true });
-  return Array.isArray(result) ? result : [];
+  if (Array.isArray(result)) {
+    return result;
+  }
+  if (import.meta.env.DEV) {
+    console.warn(`[i18n] Missing translation array for key: ${key}`);
+  }
+  return [];
 }

--- a/app/src/lib/retryableLazy.tsx
+++ b/app/src/lib/retryableLazy.tsx
@@ -1,0 +1,54 @@
+import React, { type ComponentType, Suspense } from 'react';
+import ErrorBoundary from '@/components/ErrorBoundary';
+
+interface RetryableLazyOptions {
+  /** Display name shown in React DevTools. Defaults to "RetryableLazy". */
+  name?: string;
+  /** Number of retries before page reload. Default 2. */
+  maxRetries?: number;
+}
+
+/**
+ * Wraps a React.lazy() component with:
+ * - ErrorBoundary with automatic retry
+ * - Suspense with a simple fallback
+ * - displayName for React DevTools
+ */
+export function retryableLazy<T extends ComponentType<Record<string, unknown>>>(
+  importFn: () => Promise<{ default: T }>,
+  options?: RetryableLazyOptions,
+): () => JSX.Element {
+  const LazyComponent = React.lazy(importFn);
+  const name = options?.name ?? 'RetryableLazy';
+  const maxRetries = options?.maxRetries ?? 2;
+
+  const Wrapped = () => {
+    const [retryCount, setRetryCount] = React.useState(0);
+
+    const handleRetry = () => {
+      setRetryCount((c) => {
+        const next = c + 1;
+        if (next > maxRetries) {
+          window.location.reload();
+          return c;
+        }
+        return next;
+      });
+    };
+
+    return (
+      <ErrorBoundary
+        key={retryCount}
+        onRetry={handleRetry}
+        onError={(error) => console.error(`[${name}] Chunk load error:`, error)}
+      >
+        <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Carregando...</div>}>
+          <LazyComponent />
+        </Suspense>
+      </ErrorBoundary>
+    );
+  };
+
+  Wrapped.displayName = `retryableLazy(${name})`;
+  return Wrapped;
+}

--- a/app/src/lib/retryableLazy.tsx
+++ b/app/src/lib/retryableLazy.tsx
@@ -4,15 +4,30 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 interface RetryableLazyOptions {
   /** Display name shown in React DevTools. Defaults to "RetryableLazy". */
   name?: string;
-  /** Number of retries before page reload. Default 2. */
-  maxRetries?: number;
+}
+
+/**
+ * Detects chunk-load failures (dynamic import() errors) which browsers cache
+ * by module specifier, making retry with the same import URL a no-op.
+ */
+function isChunkLoadError(error: Error): boolean {
+  return (
+    error.name === 'ChunkLoadError' ||
+    /loading (css |chunk |module )?failed/i.test(error.message) ||
+    /dynamically imported module/i.test(error.message)
+  );
 }
 
 /**
  * Wraps a React.lazy() component with:
- * - ErrorBoundary with automatic retry
+ * - ErrorBoundary that detects chunk-load failures and offers "Reload Page"
  * - Suspense with a simple fallback
  * - displayName for React DevTools
+ *
+ * For chunk-load errors (network failures during code splitting), the browser
+ * caches the failed import() by module specifier, so retrying with the same
+ * factory always re-fails. We detect these and show "Reload Page" as the
+ * primary action instead of a misleading "Try Again" button.
  */
 export function retryableLazy<T extends ComponentType<Record<string, unknown>>>(
   importFn: () => Promise<{ default: T }>,
@@ -20,27 +35,44 @@ export function retryableLazy<T extends ComponentType<Record<string, unknown>>>(
 ): () => JSX.Element {
   const LazyComponent = React.lazy(importFn);
   const name = options?.name ?? 'RetryableLazy';
-  const maxRetries = options?.maxRetries ?? 2;
 
   const Wrapped = () => {
-    const [retryCount, setRetryCount] = React.useState(0);
+    const [chunkError, setChunkError] = React.useState(false);
 
-    const handleRetry = () => {
-      setRetryCount((c) => {
-        const next = c + 1;
-        if (next > maxRetries) {
-          window.location.reload();
-          return c;
-        }
-        return next;
-      });
+    const handleError = (error: Error) => {
+      console.error(`[${name}] Load error:`, error);
+      if (isChunkLoadError(error)) {
+        setChunkError(true);
+      }
     };
+
+    // For chunk-load errors, bypass ErrorBoundary retry and show reload UI
+    if (chunkError) {
+      return (
+        <div className="flex items-center justify-center min-h-[300px] p-6">
+          <div className="bg-card border border-border rounded-xl shadow-sm max-w-md w-full p-8 text-center">
+            <h2 className="text-xl font-semibold text-foreground mb-2">
+              Failed to load
+            </h2>
+            <p className="text-muted-foreground text-sm mb-6">
+              A required component could not be loaded. This is usually caused by a network issue or after an update.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+            >
+              Reload Page
+            </button>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <ErrorBoundary
-        key={retryCount}
-        onRetry={handleRetry}
-        onError={(error) => console.error(`[${name}] Chunk load error:`, error)}
+        onRetry={() => window.location.reload()}
+        onError={handleError}
+        resetLabel="Reload Page"
       >
         <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Carregando...</div>}>
           <LazyComponent />

--- a/app/src/lib/retryableLazy.tsx
+++ b/app/src/lib/retryableLazy.tsx
@@ -4,6 +4,8 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 interface RetryableLazyOptions {
   /** Display name shown in React DevTools. Defaults to "RetryableLazy". */
   name?: string;
+  /** Custom Suspense fallback. Defaults to a generic loading spinner (no text). */
+  fallback?: React.ReactNode;
 }
 
 /**
@@ -74,7 +76,7 @@ export function retryableLazy<T extends ComponentType<Record<string, unknown>>>(
         onError={handleError}
         resetLabel="Reload Page"
       >
-        <Suspense fallback={<div className="flex items-center justify-center min-h-screen">Carregando...</div>}>
+        <Suspense fallback={options?.fallback ?? <div className="flex items-center justify-center min-h-screen"><div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" /></div>}>
           <LazyComponent />
         </Suspense>
       </ErrorBoundary>

--- a/app/src/lib/retryableLazy.tsx
+++ b/app/src/lib/retryableLazy.tsx
@@ -74,7 +74,7 @@ export function retryableLazy<T extends ComponentType<Record<string, unknown>>>(
       <ErrorBoundary
         onRetry={() => window.location.reload()}
         onError={handleError}
-        resetLabel="Reload Page"
+        resetLabel="Retry Load"
       >
         <Suspense fallback={options?.fallback ?? <div className="flex items-center justify-center min-h-screen"><div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" /></div>}>
           <LazyComponent />

--- a/app/src/test/i18nHelpers.test.ts
+++ b/app/src/test/i18nHelpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { tArray } from '@/lib/i18n-helpers';
+
+describe('tArray', () => {
+  // Simple mock: t function that resolves dotted keys from an object
+  const makeT = (translations: Record<string, unknown>) => {
+    return (key: string) => {
+      const parts = key.split('.');
+      let current: unknown = translations;
+      for (const part of parts) {
+        if (current && typeof current === 'object') {
+          current = (current as Record<string, unknown>)[part];
+        } else {
+          return undefined;
+        }
+      }
+      return current;
+    };
+  };
+
+  it('returns the array when key exists and is an array', () => {
+    const t = makeT({ foo: { bar: ['a', 'b', 'c'] } });
+    expect(tArray(t, 'foo.bar')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('returns empty array when key does not exist', () => {
+    const t = makeT({});
+    expect(tArray(t, 'missing.key')).toEqual([]);
+  });
+
+  it('returns empty array when value is not an array', () => {
+    const t = makeT({ foo: 'string-value' });
+    expect(tArray(t, 'foo')).toEqual([]);
+  });
+
+  it('returns empty array when value is an object', () => {
+    const t = makeT({ foo: { nested: 'value' } });
+    expect(tArray(t, 'foo')).toEqual([]);
+  });
+
+  it('handles empty string key', () => {
+    const t = makeT({});
+    expect(tArray(t, '')).toEqual([]);
+  });
+
+  it('handles null translation return', () => {
+    const t = () => null;
+    expect(tArray(t, 'any.key')).toEqual([]);
+  });
+});

--- a/app/src/test/recommendationScoring.test.ts
+++ b/app/src/test/recommendationScoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeUserAnswers, calculateDeviceScores, devices } from "@/components/RecommendationResults";
+import { normalizeUserAnswers, calculateDeviceScores, devices } from "@/utils/deviceScoring";
 import type { UserAnswers, DeviceScore } from "@/types/questionnaire";
 
 describe("normalizeUserAnswers", () => {

--- a/app/src/test/recommendationScoring.test.ts
+++ b/app/src/test/recommendationScoring.test.ts
@@ -1,0 +1,672 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUserAnswers, calculateDeviceScores, devices } from "@/components/RecommendationResults";
+import type { UserAnswers, DeviceScore } from "@/types/questionnaire";
+
+describe("normalizeUserAnswers", () => {
+  // ─── 1. Minimal complete answers ──────────────────────────────────
+
+  it("returns expected normalized values for complete valid answers", () => {
+    const answers: UserAnswers = {
+      electricity: "yes",
+      users: "3-5",
+      growth: "medium",
+      reuse: "no",
+      format: "yes",
+      price: "low",
+    };
+
+    const result = normalizeUserAnswers(answers);
+
+    expect(result).toEqual({
+      energy: 5,
+      concurrency: 3,
+      growth: 3,
+      reusable: 0,
+      formatEase: 5,
+      cost: 5,
+    });
+  });
+
+  it("returns expected normalized values for a different complete set", () => {
+    const answers: UserAnswers = {
+      electricity: "no",
+      users: "6+",
+      growth: "high",
+      reuse: "yes",
+      format: "no",
+      price: "high",
+    };
+
+    const result = normalizeUserAnswers(answers);
+
+    expect(result).toEqual({
+      energy: 1,
+      concurrency: 5,
+      growth: 5,
+      reusable: 5,
+      formatEase: 1,
+      cost: 1,
+    });
+  });
+
+  // ─── 2. Electricity / energy mappings ─────────────────────────────
+
+  describe("electricity → energy mapping", () => {
+    it('maps "yes" → 5 (reliable power)', () => {
+      const result = normalizeUserAnswers({ electricity: "yes" });
+      expect(result.energy).toBe(5);
+    });
+
+    it('maps "sometimes" → 3 (unreliable power)', () => {
+      const result = normalizeUserAnswers({ electricity: "sometimes" });
+      expect(result.energy).toBe(3);
+    });
+
+    it('maps "no" → 1 (frequent outages)', () => {
+      const result = normalizeUserAnswers({ electricity: "no" });
+      expect(result.energy).toBe(1);
+    });
+
+    it("defaults to 3 when electricity is undefined", () => {
+      const result = normalizeUserAnswers({});
+      expect(result.energy).toBe(3);
+    });
+
+    it("defaults to 3 when electricity is an unrecognized string", () => {
+      const result = normalizeUserAnswers({ electricity: "maybe" } as UserAnswers);
+      expect(result.energy).toBe(3);
+    });
+  });
+
+  // ─── 3. Users / concurrency mappings ──────────────────────────────
+
+  describe("users → concurrency mapping", () => {
+    it('maps "1-2" → 1 (low concurrency)', () => {
+      const result = normalizeUserAnswers({ users: "1-2" });
+      expect(result.concurrency).toBe(1);
+    });
+
+    it('maps "3-5" → 3 (medium concurrency)', () => {
+      const result = normalizeUserAnswers({ users: "3-5" });
+      expect(result.concurrency).toBe(3);
+    });
+
+    it('maps "6+" → 5 (high concurrency)', () => {
+      const result = normalizeUserAnswers({ users: "6+" });
+      expect(result.concurrency).toBe(5);
+    });
+
+    it("defaults to 1 when users is undefined (?? picks '1-2')", () => {
+      const result = normalizeUserAnswers({});
+      expect(result.concurrency).toBe(1);
+    });
+
+    it("defaults to 3 when users is an unrecognized string", () => {
+      const result = normalizeUserAnswers({ users: "1-10" } as UserAnswers);
+      expect(result.concurrency).toBe(3);
+    });
+
+    it("uses nullish coalescing — undefined users defaults to '1-2' (→ 1)", () => {
+      // The code: concurrencyMap[answers.users ?? '1-2'] || 3
+      // When users is undefined, ?? picks '1-2', which maps to 1
+      const result = normalizeUserAnswers({ users: undefined });
+      expect(result.concurrency).toBe(1);
+    });
+  });
+
+  // ─── 4. Growth mappings ───────────────────────────────────────────
+
+  describe("growth → growth mapping", () => {
+    it('maps "low" → 1', () => {
+      const result = normalizeUserAnswers({ growth: "low" });
+      expect(result.growth).toBe(1);
+    });
+
+    it('maps "medium" → 3', () => {
+      const result = normalizeUserAnswers({ growth: "medium" });
+      expect(result.growth).toBe(3);
+    });
+
+    it('maps "high" → 5', () => {
+      const result = normalizeUserAnswers({ growth: "high" });
+      expect(result.growth).toBe(5);
+    });
+
+    it('defaults to 3 for "notSure" (not in the map)', () => {
+      const result = normalizeUserAnswers({ growth: "notSure" });
+      expect(result.growth).toBe(3);
+    });
+
+    it("defaults to 3 when growth is undefined", () => {
+      const result = normalizeUserAnswers({});
+      expect(result.growth).toBe(3);
+    });
+  });
+
+  // ─── 5. Reuse mappings ────────────────────────────────────────────
+
+  describe("reuse → reusable mapping", () => {
+    it('maps "yes" → 5 (computer available for reuse)', () => {
+      const result = normalizeUserAnswers({ reuse: "yes" });
+      expect(result.reusable).toBe(5);
+    });
+
+    it('maps "no" → 0 (no computer for reuse)', () => {
+      const result = normalizeUserAnswers({ reuse: "no" });
+      expect(result.reusable).toBe(0);
+    });
+
+    it("defaults to 0 when reuse is undefined", () => {
+      const result = normalizeUserAnswers({});
+      expect(result.reusable).toBe(0);
+    });
+
+    it("defaults to 0 when reuse is an unrecognized string", () => {
+      const result = normalizeUserAnswers({ reuse: "maybe" } as UserAnswers);
+      expect(result.reusable).toBe(0);
+    });
+  });
+
+  // ─── 6. Format / formatEase mappings ──────────────────────────────
+
+  describe("format → formatEase mapping", () => {
+    it('maps "yes" → 5 (can format confidently)', () => {
+      const result = normalizeUserAnswers({ format: "yes" });
+      expect(result.formatEase).toBe(5);
+    });
+
+    it('maps "maybe" → 3 (with guidance)', () => {
+      const result = normalizeUserAnswers({ format: "maybe" });
+      expect(result.formatEase).toBe(3);
+    });
+
+    it('maps "no" → 1 (cannot format)', () => {
+      const result = normalizeUserAnswers({ format: "no" });
+      expect(result.formatEase).toBe(1);
+    });
+
+    it("defaults to 3 when format is undefined", () => {
+      const result = normalizeUserAnswers({});
+      expect(result.formatEase).toBe(3);
+    });
+
+    it("defaults to 3 when format is an unrecognized string", () => {
+      const result = normalizeUserAnswers({ format: "idk" } as UserAnswers);
+      expect(result.formatEase).toBe(3);
+    });
+  });
+
+  // ─── 7. Price / cost mappings ─────────────────────────────────────
+
+  describe("price → cost mapping", () => {
+    it('maps "low" → 5 (low budget → need low cost)', () => {
+      const result = normalizeUserAnswers({ price: "low" });
+      expect(result.cost).toBe(5);
+    });
+
+    it('maps "medium" → 3 (moderate budget)', () => {
+      const result = normalizeUserAnswers({ price: "medium" });
+      expect(result.cost).toBe(3);
+    });
+
+    it('maps "high" → 1 (high budget → cost less important)', () => {
+      const result = normalizeUserAnswers({ price: "high" });
+      expect(result.cost).toBe(1);
+    });
+
+    it("defaults to 3 when price is undefined", () => {
+      const result = normalizeUserAnswers({});
+      expect(result.cost).toBe(3);
+    });
+
+    it("defaults to 3 when price is an unrecognized string", () => {
+      const result = normalizeUserAnswers({ price: "free" } as UserAnswers);
+      expect(result.cost).toBe(3);
+    });
+  });
+
+  // ─── 8. Edge cases ────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("returns all defaults for an empty answers object", () => {
+      const result = normalizeUserAnswers({});
+
+      expect(result).toEqual({
+        energy: 3,
+        concurrency: 1,   // undefined → ?? picks '1-2' → 1
+        growth: 3,
+        reusable: 0,
+        formatEase: 3,
+        cost: 3,
+      });
+    });
+
+    it("handles partial answers — mixes explicit values with defaults", () => {
+      const result = normalizeUserAnswers({
+        electricity: "yes",
+        reuse: "yes",
+      });
+
+      expect(result).toEqual({
+        energy: 5,          // explicit
+        concurrency: 1,     // undefined → ?? picks '1-2' → 1
+        growth: 3,          // default
+        reusable: 5,        // explicit
+        formatEase: 3,      // default
+        cost: 3,            // default
+      });
+    });
+
+    it("handles another partial combination", () => {
+      const result = normalizeUserAnswers({
+        users: "1-2",
+        growth: "low",
+        price: "high",
+      });
+
+      expect(result).toEqual({
+        energy: 3,          // default
+        concurrency: 1,     // explicit: '1-2' → 1
+        growth: 1,          // explicit: 'low' → 1
+        reusable: 0,        // default
+        formatEase: 3,      // default
+        cost: 1,            // explicit: 'high' → 1
+      });
+    });
+
+    it("ignores extra unknown keys in the answers object", () => {
+      const result = normalizeUserAnswers({
+        electricity: "yes",
+        someUnknownField: "value",
+      } as UserAnswers);
+
+      expect(result.energy).toBe(5);
+      // other fields use defaults — concurrency uses ?? fallback '1-2' → 1
+      expect(result.concurrency).toBe(1);
+    });
+
+    it("maps every field correctly for a realistic questionnaire response", () => {
+      // Simulate what a real user might answer
+      const answers: UserAnswers = {
+        electricity: "sometimes",
+        users: "3-5",
+        growth: "high",
+        reuse: "no",
+        format: "maybe",
+        price: "medium",
+      };
+
+      const result = normalizeUserAnswers(answers);
+
+      expect(result).toEqual({
+        energy: 3,       // sometimes
+        concurrency: 3,  // 3-5
+        growth: 5,       // high
+        reusable: 0,     // no
+        formatEase: 3,   // maybe
+        cost: 3,         // medium
+      });
+    });
+  });
+});
+
+// ─── calculateDeviceScores ────────────────────────────────────────
+
+describe("calculateDeviceScores", () => {
+  // Shared helpers
+  const norm = (answers: UserAnswers) => normalizeUserAnswers(answers);
+
+  const baseAnswers: UserAnswers = {
+    electricity: "yes",
+    users: "3-5",
+    growth: "medium",
+    reuse: "no",
+    format: "yes",
+    price: "low",
+    points: { lowPower: 5, scalable: 5, easyToUse: 5, lowCost: 5 },
+  };
+
+  // ─── 1. Basic scoring ────────────────────────────────────────────
+
+  describe("basic scoring", () => {
+    it("returns results for all 4 devices sorted by matchPercentage descending", () => {
+      const results = calculateDeviceScores(baseAnswers, norm(baseAnswers));
+
+      expect(results).toHaveLength(4);
+
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].matchPercentage).toBeGreaterThanOrEqual(
+          results[i].matchPercentage,
+        );
+      }
+    });
+
+    it("each result has the expected DeviceScore shape", () => {
+      const results = calculateDeviceScores(baseAnswers, norm(baseAnswers));
+
+      for (const r of results) {
+        expect(r).toHaveProperty("device");
+        expect(r).toHaveProperty("score");
+        expect(r).toHaveProperty("matchPercentage");
+        expect(r).toHaveProperty("strengths");
+        expect(r.device).toHaveProperty("key");
+        expect(r.device).toHaveProperty("name");
+        expect(typeof r.score).toBe("number");
+        expect(typeof r.matchPercentage).toBe("number");
+        expect(Array.isArray(r.strengths)).toBe(true);
+      }
+    });
+
+    it("matchPercentage for every device is in the 0–100 range", () => {
+      const results = calculateDeviceScores(baseAnswers, norm(baseAnswers));
+
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+        expect(r.matchPercentage).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it("all 4 known device keys are present in results", () => {
+      const results = calculateDeviceScores(baseAnswers, norm(baseAnswers));
+      const keys = results.map((r) => r.device.key).sort();
+
+      expect(keys).toEqual([
+        "intelNUC",
+        "raspberryPi",
+        "reusedPC",
+        "zimaBoard",
+      ]);
+    });
+
+    it("produces different match percentages for different devices (scoring is not flat)", () => {
+      const results = calculateDeviceScores(baseAnswers, norm(baseAnswers));
+      const percentages = results.map((r) => r.matchPercentage);
+      const unique = new Set(percentages);
+
+      // At least 2 devices should have different percentages
+      expect(unique.size).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // ─── 2. Concurrency weight ───────────────────────────────────────
+
+  describe("concurrency weight", () => {
+    it("1–2 users produce different scores than 6+ users for the same device", () => {
+      const fewUsers: UserAnswers = { ...baseAnswers, users: "1-2" };
+      const manyUsers: UserAnswers = { ...baseAnswers, users: "6+" };
+
+      const resultsFew = calculateDeviceScores(fewUsers, norm(fewUsers));
+      const resultsMany = calculateDeviceScores(manyUsers, norm(manyUsers));
+
+      const piFew = resultsFew.find((r) => r.device.key === "raspberryPi")!;
+      const piMany = resultsMany.find((r) => r.device.key === "raspberryPi")!;
+
+      // Scores should differ because concurrency weight changes (0.5 vs 3)
+      // AND the normalizedAnswers.concurrency changes (1 vs 5)
+      expect(piFew.matchPercentage).not.toBe(piMany.matchPercentage);
+    });
+
+    it("concurrency weight is 0 when no priority attributes have points", () => {
+      // No priority points → totalPoints = 0 → equal weights (1/6 each).
+      // Even though concurrency starts at 0 in pointWeights, the equal-weight
+      // fallback gives it 1/6 anyway. The test verifies the function works.
+      const noPriorities: UserAnswers = {
+        electricity: "yes",
+        users: "6+",
+        growth: "medium",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        points: { lowPower: 0, scalable: 0, easyToUse: 0, lowCost: 0 },
+      };
+
+      const results = calculateDeviceScores(noPriorities, norm(noPriorities));
+
+      expect(results).toHaveLength(4);
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("3–5 users produce valid results (mid-range concurrency weight)", () => {
+      const midUsers: UserAnswers = { ...baseAnswers, users: "3-5" };
+      const results = calculateDeviceScores(midUsers, norm(midUsers));
+
+      expect(results).toHaveLength(4);
+      expect(results[0].matchPercentage).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  // ─── 3. Language redistribution ──────────────────────────────────
+
+  describe("language redistribution", () => {
+    it("distributes language points proportionally among the 4 priority attributes", () => {
+      // lowPower=10, scalable=5, easyToUse=5, lowCost=0, language=20
+      // totalPriorityPoints = 10+5+5+0 = 20
+      // energy  += 20 * (10/20) = 10  → 10+10 = 20
+      // growth  += 20 * (5/20)  =  5  →  5+5  = 10
+      // formatEase += 20 * (5/20) =  5  →  5+5  = 10
+      // cost stays at 0
+      // This makes energy heavily dominant
+      const answers: UserAnswers = {
+        ...baseAnswers,
+        points: {
+          lowPower: 10,
+          scalable: 5,
+          easyToUse: 5,
+          lowCost: 0,
+          language: 20,
+        },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      expect(results).toHaveLength(4);
+
+      // With energy heavily weighted (20 out of ~41.5 total),
+      // Raspberry Pi (energy=5) should rank very highly
+      const pi = results.find((r) => r.device.key === "raspberryPi")!;
+      expect(pi.matchPercentage).toBeGreaterThan(0);
+    });
+
+    it("distributes language points equally when all other priorities are 0", () => {
+      // All priorities 0, language=20 → 20/4 = 5 each to energy, growth, formatEase, cost
+      // concurrency weight = 0 (no priorities have >0 points)
+      const answers: UserAnswers = {
+        ...baseAnswers,
+        points: {
+          lowPower: 0,
+          scalable: 0,
+          easyToUse: 0,
+          lowCost: 0,
+          language: 20,
+        },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      expect(results).toHaveLength(4);
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+        expect(r.matchPercentage).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it("no language points → no redistribution (weights unchanged)", () => {
+      const noLanguage: UserAnswers = {
+        ...baseAnswers,
+        points: { lowPower: 10, scalable: 10, easyToUse: 10, lowCost: 10 },
+      };
+      const withLanguage: UserAnswers = {
+        ...baseAnswers,
+        points: {
+          lowPower: 10,
+          scalable: 10,
+          easyToUse: 10,
+          lowCost: 10,
+          language: 20,
+        },
+      };
+
+      const resultsNoLang = calculateDeviceScores(noLanguage, norm(noLanguage));
+      const resultsWithLang = calculateDeviceScores(
+        withLanguage,
+        norm(withLanguage),
+      );
+
+      // Adding language points changes the distribution — the raw score
+      // must differ even if the rounded matchPercentage happens to be the same.
+      const piNoLang = resultsNoLang.find(
+        (r) => r.device.key === "raspberryPi",
+      )!;
+      const piWithLang = resultsWithLang.find(
+        (r) => r.device.key === "raspberryPi",
+      )!;
+      expect(piNoLang.score).not.toBe(piWithLang.score);
+    });
+  });
+
+  // ─── 4. Reuse special handling ───────────────────────────────────
+
+  describe("reuse special handling", () => {
+    it("reuse=yes → reusable attribute gets 40% weight, reusedPC tops the ranking", () => {
+      const withReuse: UserAnswers = { ...baseAnswers, reuse: "yes" };
+      const results = calculateDeviceScores(withReuse, norm(withReuse));
+
+      expect(results).toHaveLength(4);
+
+      // Reused PC has reusable=5, others have reusable=0.
+      // With 40% weight on reusable and user reusable=5 (reuse=yes → 5),
+      // reusedPC gets a huge advantage and should be #1
+      expect(results[0].device.key).toBe("reusedPC");
+    });
+
+    it("reuse=no → reusable gets 0 weight (no reuse boost)", () => {
+      const withoutReuse: UserAnswers = { ...baseAnswers, reuse: "no" };
+      const results = calculateDeviceScores(withoutReuse, norm(withoutReuse));
+
+      expect(results).toHaveLength(4);
+
+      // reusedPC is NOT necessarily top — its reusable=5 advantage is neutralized
+      // At least verify all match percentages are valid
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("reuse=yes changes top device compared to reuse=no", () => {
+      const withReuse: UserAnswers = { ...baseAnswers, reuse: "yes" };
+      const withoutReuse: UserAnswers = { ...baseAnswers, reuse: "no" };
+
+      const resultsWith = calculateDeviceScores(withReuse, norm(withReuse));
+      const resultsWithout = calculateDeviceScores(
+        withoutReuse,
+        norm(withoutReuse),
+      );
+
+      // Top device differs between the two scenarios
+      expect(resultsWith[0].device.key).not.toBe(resultsWithout[0].device.key);
+    });
+  });
+
+  // ─── 5. Edge cases ───────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("no user priorities → all attributes weighted equally", () => {
+      // points are all 0 or missing → totalPoints = 0 → equal weights (1/6 each)
+      const answers: UserAnswers = {
+        electricity: "yes",
+        users: "3-5",
+        growth: "medium",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        // No points at all
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      expect(results).toHaveLength(4);
+      for (let i = 1; i < results.length; i++) {
+        expect(results[i - 1].matchPercentage).toBeGreaterThanOrEqual(
+          results[i].matchPercentage,
+        );
+      }
+    });
+
+    it("exact attribute match → yields similarity = 5 (perfect match)", () => {
+      // When user's reusable=5 (reuse=yes) and device's reusable=5 (Reused PC),
+      // similarity = 5 - |5-5| = 5. When user's reusable=5 and device's
+      // reusable=0 (Raspberry Pi), similarity = 5 - |5-0| = 0.
+      // This difference, combined with the 40% reuse weight, makes Reused PC win.
+      const answers: UserAnswers = {
+        ...baseAnswers,
+        reuse: "yes",
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      // The perfect match on reusable (5 vs 5) with 40% weight should
+      // make Reused PC the top device
+      expect(results[0].device.key).toBe("reusedPC");
+    });
+
+    it("matchPercentage is never negative (guard clause)", () => {
+      // Even with extreme inputs, the division guard ensures matchPercentage >= 0
+      const answers: UserAnswers = {
+        electricity: "no",
+        users: "6+",
+        growth: "high",
+        reuse: "yes",
+        format: "no",
+        price: "high",
+        points: { lowPower: 0, scalable: 0, easyToUse: 0, lowCost: 0 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+        expect(r.matchPercentage).toBeLessThanOrEqual(100);
+      }
+    });
+
+    it("handles missing points key entirely (undefined)", () => {
+      const answers: UserAnswers = {
+        electricity: "yes",
+        users: "3-5",
+        growth: "medium",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        // points is undefined
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      expect(results).toHaveLength(4);
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+      }
+    });
+
+    it("handles points with only language set (everything else missing)", () => {
+      const answers: UserAnswers = {
+        electricity: "yes",
+        users: "3-5",
+        growth: "medium",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        points: { language: 20 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      expect(results).toHaveLength(4);
+      for (const r of results) {
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+      }
+    });
+  });
+});

--- a/app/src/test/recommendationScoring.test.ts
+++ b/app/src/test/recommendationScoring.test.ts
@@ -18,11 +18,11 @@ describe("normalizeUserAnswers", () => {
     const result = normalizeUserAnswers(answers);
 
     expect(result).toEqual({
-      energy: 5,
+      energy: 1, // 'yes' → reliable power → low need for efficiency
       concurrency: 3,
       growth: 3,
       reusable: 0,
-      formatEase: 5,
+      formatEase: 1, // 'yes' → can format → low need for easy setup
       cost: 5,
     });
   });
@@ -40,11 +40,11 @@ describe("normalizeUserAnswers", () => {
     const result = normalizeUserAnswers(answers);
 
     expect(result).toEqual({
-      energy: 1,
+      energy: 5, // 'no' → frequent outages → high need for efficiency
       concurrency: 5,
       growth: 5,
       reusable: 5,
-      formatEase: 1,
+      formatEase: 5, // 'no' → cannot format → high need for easy setup
       cost: 1,
     });
   });
@@ -52,19 +52,19 @@ describe("normalizeUserAnswers", () => {
   // ─── 2. Electricity / energy mappings ─────────────────────────────
 
   describe("electricity → energy mapping", () => {
-    it('maps "yes" → 5 (reliable power)', () => {
+    it('maps "yes" → 1 (reliable power → low need for efficiency)', () => {
       const result = normalizeUserAnswers({ electricity: "yes" });
-      expect(result.energy).toBe(5);
+      expect(result.energy).toBe(1);
     });
 
-    it('maps "sometimes" → 3 (unreliable power)', () => {
+    it('maps "sometimes" → 3 (unreliable power → moderate need)', () => {
       const result = normalizeUserAnswers({ electricity: "sometimes" });
       expect(result.energy).toBe(3);
     });
 
-    it('maps "no" → 1 (frequent outages)', () => {
+    it('maps "no" → 5 (frequent outages → high need for efficiency)', () => {
       const result = normalizeUserAnswers({ electricity: "no" });
-      expect(result.energy).toBe(1);
+      expect(result.energy).toBe(5);
     });
 
     it("defaults to 3 when electricity is undefined", () => {
@@ -170,19 +170,19 @@ describe("normalizeUserAnswers", () => {
   // ─── 6. Format / formatEase mappings ──────────────────────────────
 
   describe("format → formatEase mapping", () => {
-    it('maps "yes" → 5 (can format confidently)', () => {
+    it('maps "yes" → 1 (can format confidently → low need for easy setup)', () => {
       const result = normalizeUserAnswers({ format: "yes" });
-      expect(result.formatEase).toBe(5);
+      expect(result.formatEase).toBe(1);
     });
 
-    it('maps "maybe" → 3 (with guidance)', () => {
+    it('maps "maybe" → 3 (with guidance → moderate need)', () => {
       const result = normalizeUserAnswers({ format: "maybe" });
       expect(result.formatEase).toBe(3);
     });
 
-    it('maps "no" → 1 (cannot format)', () => {
+    it('maps "no" → 5 (cannot format → high need for easy setup)', () => {
       const result = normalizeUserAnswers({ format: "no" });
-      expect(result.formatEase).toBe(1);
+      expect(result.formatEase).toBe(5);
     });
 
     it("defaults to 3 when format is undefined", () => {
@@ -248,9 +248,9 @@ describe("normalizeUserAnswers", () => {
       });
 
       expect(result).toEqual({
-        energy: 5,          // explicit
+        energy: 1,     // 'yes' → reliable power → low need
         concurrency: 1,     // undefined → ?? picks '1-2' → 1
-        growth: 3,          // default
+        growth: 3,
         reusable: 5,        // explicit
         formatEase: 3,      // default
         cost: 3,            // default
@@ -280,7 +280,7 @@ describe("normalizeUserAnswers", () => {
         someUnknownField: "value",
       } as UserAnswers);
 
-      expect(result.energy).toBe(5);
+      expect(result.energy).toBe(1); // 'yes' → low need for efficiency
       // other fields use defaults — concurrency uses ?? fallback '1-2' → 1
       expect(result.concurrency).toBe(1);
     });
@@ -554,18 +554,28 @@ describe("calculateDeviceScores", () => {
       }
     });
 
-    it("reuse=yes changes top device compared to reuse=no", () => {
-      const withReuse: UserAnswers = { ...baseAnswers, reuse: "yes" };
-      const withoutReuse: UserAnswers = { ...baseAnswers, reuse: "no" };
+    it("reuse=yes boosts reusedPC ranking relative to its reuse=no position", () => {
+      // Use a profile where reusedPC is NOT top without reuse boost:
+      // frequent outages + cannot format + low budget favors Pi
+      const baseProfile: UserAnswers = {
+        electricity: "no", // frequent outages → energy need = 5
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "no", // cannot format → formatEase need = 5
+        price: "low",
+        points: { lowPower: 5, scalable: 0, easyToUse: 5, lowCost: 5 },
+      };
+      const withReuse: UserAnswers = { ...baseProfile, reuse: "yes" };
 
+      const resultsWithout = calculateDeviceScores(baseProfile, norm(baseProfile));
       const resultsWith = calculateDeviceScores(withReuse, norm(withReuse));
-      const resultsWithout = calculateDeviceScores(
-        withoutReuse,
-        norm(withoutReuse),
-      );
 
-      // Top device differs between the two scenarios
-      expect(resultsWith[0].device.key).not.toBe(resultsWithout[0].device.key);
+      // Without reuse, Raspberry Pi should be #1 (energy efficient + cheap)
+      expect(resultsWithout[0].device.key).toBe("raspberryPi");
+
+      // With reuse, reusedPC jumps to #1 due to 40% reusable weight
+      expect(resultsWith[0].device.key).toBe("reusedPC");
     });
   });
 
@@ -667,6 +677,101 @@ describe("calculateDeviceScores", () => {
       for (const r of results) {
         expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
       }
+    });
+  });
+
+  // ─── 6. Semantic correctness ─────────────────────────────────────
+
+  describe("semantic correctness — correct device for user profile", () => {
+    it("user with frequent outages ranks Raspberry Pi above Reused PC", () => {
+      // User has frequent power outages → needs energy efficiency
+      // Raspberry Pi (energy=5) should score higher than Reused PC (energy=1)
+      const answers: UserAnswers = {
+        electricity: "no", // frequent outages → energy need = 5
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        points: { lowPower: 10, scalable: 0, easyToUse: 0, lowCost: 0 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+      const pi = results.find((r) => r.device.key === "raspberryPi")!;
+      const reusedPC = results.find((r) => r.device.key === "reusedPC")!;
+
+      expect(pi.score).toBeGreaterThan(reusedPC.score);
+    });
+
+    it("user who cannot format ranks easier devices above harder ones", () => {
+      // User cannot format → needs easy setup
+      // Devices with higher formatEase should score better for this user
+      // Raspberry Pi (formatEase=3) vs ZimaBoard (formatEase=2) vs Reused PC (formatEase=2)
+      const answers: UserAnswers = {
+        electricity: "yes",
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "no", // cannot format → formatEase need = 5
+        price: "medium",
+        points: { lowPower: 0, scalable: 0, easyToUse: 10, lowCost: 0 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+      const pi = results.find((r) => r.device.key === "raspberryPi")!;
+      const zima = results.find((r) => r.device.key === "zimaBoard")!;
+      const reusedPC = results.find((r) => r.device.key === "reusedPC")!;
+
+      // Raspberry Pi (formatEase=3) is closest to user need (5) among non-NUC devices
+      // NUC (formatEase=3) ties with Pi on formatEase, but Pi is cheaper (cost=5 vs cost=1)
+      expect(pi.score).toBeGreaterThan(zima.score);
+      expect(pi.score).toBeGreaterThan(reusedPC.score);
+    });
+
+    it("user with reliable power does not strongly prefer energy-efficient devices", () => {
+      // With reliable power (energy need = 1), the energy attribute contributes
+      // equally for all devices since the user has no special need.
+      // Reused PC (energy=1) and Pi (energy=5) should have similar energy scores
+      // when the user's energy need is low (1).
+      const answers: UserAnswers = {
+        electricity: "yes", // reliable power → energy need = 1
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        points: { lowPower: 10, scalable: 0, easyToUse: 0, lowCost: 0 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      // Reused PC (energy=1) should match user energy need (1) perfectly
+      // Pi (energy=5) should have a larger gap from user need (1)
+      const reusedPC = results.find((r) => r.device.key === "reusedPC")!;
+      const pi = results.find((r) => r.device.key === "raspberryPi")!;
+
+      // When user need=1, Reused PC (1) gets similarity=5, Pi (5) gets similarity=1
+      // So with lowPower priority, Reused PC wins on energy
+      expect(reusedPC.score).toBeGreaterThan(pi.score);
+    });
+
+    it("combined: frequent outages + cannot format + low budget favors Raspberry Pi", () => {
+      const answers: UserAnswers = {
+        electricity: "no", // frequent outages → high energy need
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "no", // cannot format → high need for easy setup
+        price: "low", // low budget → need low cost
+        points: { lowPower: 5, scalable: 0, easyToUse: 5, lowCost: 5 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      // Raspberry Pi: energy=5, formatEase=3, cost=5 — strong on energy & cost
+      // NUC: energy=2, formatEase=3, cost=1 — bad on energy & cost
+      // Reused PC: energy=1, formatEase=2, cost=4 — worst on energy
+      expect(results[0].device.key).toBe("raspberryPi");
     });
   });
 });

--- a/app/src/test/recommendationScoring.test.ts
+++ b/app/src/test/recommendationScoring.test.ts
@@ -773,5 +773,116 @@ describe("calculateDeviceScores", () => {
       // Reused PC: energy=1, formatEase=2, cost=4 — worst on energy
       expect(results[0].device.key).toBe("raspberryPi");
     });
+
+    it("strengths array contains matching attribute keys for a well-matched device", () => {
+      // User with frequent outages → energy need=5 matches Pi energy=5 → similarity=5
+      const answers: UserAnswers = {
+        electricity: "no", // energy need = 5
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        points: { lowPower: 5, scalable: 0, easyToUse: 0, lowCost: 5 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+      const pi = results.find((r) => r.device.key === "raspberryPi")!;
+
+      // Pi (energy=5) perfectly matches user energy need (5) → similarity=5 >= 4
+      expect(pi.strengths).toContain("energy");
+      // Pi (cost=5) matches user low budget (5) → similarity=5 >= 4
+      expect(pi.strengths).toContain("cost");
+    });
+
+    it("perfect match profile scores 100% with equal weights and reuse override", () => {
+      // Reused PC: energy=1, concurrency=4, growth=4, reusable=5, formatEase=2, cost=4
+      // With reuse="yes", reusable gets 40% weight
+      // Other attributes get equal share of 60%
+      const answers: UserAnswers = {
+        electricity: "no",        // energy need = 5 → gap |5-1|=4 → similarity=1
+        users: "1-2",             // concurrency need = 1 → gap |1-4|=3 → similarity=2
+        growth: "low",            // growth need = 1 → gap |1-4|=3 → similarity=2
+        reuse: "yes",             // reusable gets 40% weight boost
+        format: "yes",            // formatEase need = 1 → gap |1-2|=1 → similarity=4
+        price: "medium",          // cost need = 3 → gap |3-4|=1 → similarity=4
+        // no points → equal weights
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+      const reusedPC = results.find((r) => r.device.key === "reusedPC")!;
+
+      // With reuse="yes", reusedPC gets 40% weight on reusable where it's 5/5
+      // This gives it a dominant match over other devices
+      expect(results[0].device.key).toBe("reusedPC");
+      expect(reusedPC.matchPercentage).toBeGreaterThan(70);
+    });
+
+    it("tie-breaking: devices with equal scores sort consistently", () => {
+      // Deliberately create a profile where two devices should tie
+      // by giving no priority points (equal weights) and neutral answers
+      const answers: UserAnswers = {
+        electricity: "yes",
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "yes",
+        price: "medium",
+        // no points → equal weights
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+      const sortOrder = results.map((r) => r.device.key);
+      const sortedScores = results.map((r) => r.score);
+
+      // Verify scores are sorted descending (already sorted by function contract)
+      for (let i = 1; i < sortedScores.length; i++) {
+        expect(sortedScores[i]).toBeLessThanOrEqual(sortedScores[i - 1]);
+      }
+
+      // Re-run and verify same sort order (stability)
+      const results2 = calculateDeviceScores(answers, norm(answers));
+      expect(results2.map((r) => r.device.key)).toEqual(sortOrder);
+    });
+
+    it("language redistribution with single non-zero priority: all language flows into that priority", () => {
+      // Only lowPower=10 is set, plus language=20
+      // All 20 language points should be proportional-assigned to lowPower
+      const answers: UserAnswers = {
+        electricity: "no",
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "yes",
+        price: "low",
+        points: { lowPower: 10, scalable: 0, easyToUse: 0, lowCost: 0, language: 20 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+      const pi = results.find((r) => r.device.key === "raspberryPi")!;
+      // Pi wins on energy+cost, and with all points in energy, it should rank first
+      expect(pi.score).toBeGreaterThan(0);
+      expect(results[0].device.key).toBe("raspberryPi");
+    });
+
+    it("handles negative and out-of-range point values without NaN", () => {
+      const answers: UserAnswers = {
+        electricity: "yes",
+        users: "1-2",
+        growth: "low",
+        reuse: "no",
+        format: "yes",
+        price: "medium",
+        points: { lowPower: -5, scalable: 0, easyToUse: 0, lowCost: 0 },
+      };
+
+      const results = calculateDeviceScores(answers, norm(answers));
+
+      results.forEach((r) => {
+        expect(isNaN(r.score)).toBe(false);
+        expect(isNaN(r.matchPercentage)).toBe(false);
+        expect(r.matchPercentage).toBeGreaterThanOrEqual(0);
+      });
+    });
   });
 });

--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/app/src/test/smoke.test.ts
+++ b/app/src/test/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('test infrastructure', () => {
+  it('runs', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/app/src/utils/deviceScoring.tsx
+++ b/app/src/utils/deviceScoring.tsx
@@ -1,0 +1,263 @@
+import type { ReactNode } from 'react';
+import type {
+  AttributeKey,
+  DeviceAttributes,
+  DeviceScore,
+  PriorityAllocation,
+  UserAnswers,
+} from '@/types/questionnaire';
+
+// Import board images
+import raspberryPiImage from '../assets/pi.png';
+import zimaImage from '../assets/zima.png';
+import nucImage from '../assets/nuc.png';
+import reusedPCImage from '../assets/laptop.jpg'; // Using banner as placeholder for reused PC
+
+// Define the devices with their attributes
+export const devices: DeviceAttributes[] = [
+  {
+    key: 'raspberryPi',
+    name: 'Raspberry Pi',
+    energy: 5, // Very energy efficient
+    concurrency: 1, // Poor for multiple users
+    growth: 2, // Limited growth potential
+    reusable: 0, // Not reusable (new hardware)
+    formatEase: 3, // Moderate setup difficulty
+    cost: 5, // Very low cost
+    icon: <img src={raspberryPiImage} alt="Raspberry Pi" className="h-full w-full object-cover" />
+  },
+  {
+    key: 'zimaBoard',
+    name: 'ZimaBoard',
+    energy: 4, // Good energy efficiency
+    concurrency: 3, // Moderate multi-user support
+    growth: 3, // Moderate growth potential
+    reusable: 0, // Not reusable (new hardware)
+    formatEase: 2, // More difficult to set up
+    cost: 3, // Moderate cost
+    icon: <img src={zimaImage} alt="ZimaBoard" className="h-full w-full object-cover" />
+  },
+  {
+    key: 'intelNUC',
+    name: 'Intel NUC',
+    energy: 2, // Higher power consumption
+    concurrency: 5, // Excellent for multiple users
+    growth: 5, // Excellent growth potential
+    reusable: 0, // Not reusable (new hardware)
+    formatEase: 3, // Moderate setup difficulty
+    cost: 1, // High cost
+    icon: <img src={nucImage} alt="Intel NUC" className="h-full w-full object-cover" />
+  },
+  {
+    key: 'reusedPC',
+    name: 'Reused PC',
+    energy: 1, // High power consumption
+    concurrency: 4, // Good for multiple users
+    growth: 4, // Good growth potential
+    reusable: 5, // Excellent reusability (existing hardware)
+    formatEase: 2, // More difficult to set up
+    cost: 4, // Low cost (reused)
+    icon: <img src={reusedPCImage} alt="Recycled laptop" className="h-full w-full object-cover" />
+  }
+];
+
+// Function to normalize user answers to the 1-5 scale
+export const normalizeUserAnswers = (answers: UserAnswers): Record<AttributeKey, number> => {
+  // Map electricity answer to energy score (1-5)
+  // Higher value = greater need for energy efficiency.
+  // The similarity formula (5 - |user - device|) matches user needs to device capabilities,
+  // so a user with frequent outages (high need) gets a high value, matching efficient devices.
+  const energyMap: Record<string, number> = {
+    'yes': 1, // Reliable power → low need for efficiency
+    'sometimes': 3, // Unreliable → moderate need for efficiency
+    'no': 5 // Frequent outages → high need for efficiency
+  };
+
+  // Map users answer to concurrency score (1-5)
+  const concurrencyMap: Record<string, number> = {
+    '1-2': 1, // Few users -> low concurrency needs
+    '3-5': 3, // Medium users -> moderate concurrency needs
+    '6+': 5 // Many users -> high concurrency needs
+  };
+
+  // Map growth answer to growth score (1-5)
+  const growthMap: Record<string, number> = {
+    'low': 1, // Minimal growth -> low growth needs
+    'medium': 3, // Moderate growth -> moderate growth needs
+    'high': 5 // Rapid growth -> high growth needs
+  };
+
+  // Map reuse answer to reusable score (0 or 5)
+  const reusableMap: Record<string, number> = {
+    'yes': 5, // Has computer for reuse -> high reusability
+    'no': 0 // No computer for reuse -> no reusability
+  };
+
+  // Map format answer to formatEase score (1-5)
+  // Higher value = greater need for easy setup.
+  // The similarity formula (5 - |user - device|) matches user needs to device capabilities,
+  // so a user who cannot format (high need for easy setup) gets a high value,
+  // matching devices that are easier to set up.
+  const formatEaseMap: Record<string, number> = {
+    'yes': 1, // Can format confidently → low need for easy setup
+    'maybe': 3, // With guidance → moderate need for easy setup
+    'no': 5 // Cannot format → high need for easy setup
+  };
+
+  // Map price answer to cost score (1-5)
+  const costMap: Record<string, number> = {
+    'low': 5, // Low budget -> need low cost
+    'medium': 3, // Medium budget -> moderate cost acceptable
+    'high': 1 // High budget -> cost less important
+  };
+
+  return {
+    energy: energyMap[answers.electricity] || 3,
+    concurrency: concurrencyMap[answers.users ?? '1-2'] || 3,
+    growth: growthMap[answers.growth] || 3,
+    reusable: reusableMap[answers.reuse] || 0,
+    formatEase: formatEaseMap[answers.format] || 3,
+    cost: costMap[answers.price] || 3
+  };
+};
+
+// Function to calculate device scores based on user answers and point allocation
+export const calculateDeviceScores = (
+  answers: UserAnswers,
+  normalizedAnswers: Record<AttributeKey, number>
+): DeviceScore[] => {
+  const points: PriorityAllocation = answers.points ?? {};
+
+  // Get point weights from user's point allocation
+  // Mapping: easyToUse→formatEase, lowPower→energy, scalable→growth, lowCost→cost
+  // language is excluded from device scoring (no corresponding hardware attribute).
+  // Its points are redistributed proportionally among the other 4 priority-driven attributes.
+  // concurrency is driven by the `users` answer, not by priorities — it gets a baseline weight
+  // proportional to the user's concurrency needs so that multi-user scenarios influence rankings.
+  // reusable is driven by the `reuse` answer special case below, not by priorities.
+
+  const languagePoints = points.language ?? 0;
+  const priorityKeys: AttributeKey[] = ['energy', 'growth', 'formatEase', 'cost'];
+
+  // Start with direct priority allocations
+  const pointWeights: Record<AttributeKey, number> = {
+    energy: points.lowPower ?? 0,
+    concurrency: 0,
+    growth: points.scalable ?? 0,
+    reusable: 0,
+    formatEase: points.easyToUse ?? 0,
+    cost: points.lowCost ?? 0
+  };
+
+  // Redistribute language points proportionally among the 4 priority-driven attributes
+  if (languagePoints > 0) {
+    const totalPriorityPoints = priorityKeys.reduce((sum, key) => sum + pointWeights[key], 0);
+    if (totalPriorityPoints > 0) {
+      // Distribute proportionally to existing allocations
+      priorityKeys.forEach(key => {
+        pointWeights[key] += languagePoints * (pointWeights[key] / totalPriorityPoints);
+      });
+    } else {
+      // All priorities were 0 — distribute equally
+      const share = languagePoints / priorityKeys.length;
+      priorityKeys.forEach(key => {
+        pointWeights[key] = share;
+      });
+    }
+  }
+
+  // Derive concurrency baseline weight from the `users` answer
+  // More users → higher concurrency weight so multi-user needs influence device ranking
+  const concurrencyBaselineWeight: Record<string, number> = {
+    '1-2': 0.5,   // Low concurrency need — small baseline weight
+    '3-5': 1.5,   // Moderate — meaningful weight
+    '6+': 3,      // High — strong influence on ranking
+  };
+  const rawUsers = answers.users ?? '1-2';
+  // User allocated at least one priority point (any priority or language)
+  const userAllocatedPoints = Object.values(points).some(p => p > 0);
+  pointWeights.concurrency = userAllocatedPoints
+    ? (concurrencyBaselineWeight[rawUsers] ?? 0.5)
+    : 0;
+
+  // Calculate total points allocated
+  const totalPoints = Object.values(pointWeights).reduce((sum, points) => sum + points, 0);
+
+  // Calculate normalized weights (ensure sum is 1.0)
+  const normalizedWeights: Record<AttributeKey, number> = {} as Record<AttributeKey, number>;
+
+  if (totalPoints > 0) {
+    Object.keys(pointWeights).forEach(key => {
+      normalizedWeights[key as AttributeKey] = pointWeights[key as AttributeKey] / totalPoints;
+    });
+  } else {
+    // If no points allocated, use equal weights
+    const equalWeight = 1 / Object.keys(pointWeights).length;
+    Object.keys(pointWeights).forEach(key => {
+      normalizedWeights[key as AttributeKey] = equalWeight;
+    });
+  }
+
+  // Special case: if user has a computer for reuse, heavily weight the reusable attribute
+  if (answers.reuse === 'yes') {
+    normalizedWeights.reusable = 0.4; // 40% weight to reusability
+
+    // Redistribute remaining 60% proportionally among other attributes,
+    // preserving derived weights (e.g. concurrency from the `users` answer)
+    const otherAttributes = Object.keys(normalizedWeights).filter(key => key !== 'reusable') as AttributeKey[];
+    const otherTotal = otherAttributes.reduce((sum, key) => sum + normalizedWeights[key], 0);
+
+    if (otherTotal > 0) {
+      // Scale existing proportions to fill the remaining 60%
+      otherAttributes.forEach(key => {
+        normalizedWeights[key] = 0.6 * (normalizedWeights[key] / otherTotal);
+      });
+    } else {
+      // Fallback: equal distribution if all weights were zero
+      const weightPerAttribute = 0.6 / otherAttributes.length;
+      otherAttributes.forEach(key => {
+        normalizedWeights[key] = weightPerAttribute;
+      });
+    }
+  }
+
+  // Calculate scores for each device
+  return devices.map(device => {
+    // Calculate weighted score for each attribute
+    let totalScore = 0;
+    const strengths: AttributeKey[] = [];
+
+    Object.keys(normalizedAnswers).forEach(key => {
+      const attributeKey = key as AttributeKey;
+      const userValue = normalizedAnswers[attributeKey];
+      const deviceValue = device[attributeKey];
+
+      // Calculate similarity (5 - absolute difference)
+      // Higher similarity means better match
+      const similarity = 5 - Math.abs(userValue - deviceValue);
+
+      // Apply weight to similarity
+      const weightedSimilarity = similarity * normalizedWeights[attributeKey];
+
+      // Add to total score
+      totalScore += weightedSimilarity;
+
+      // If this is a strength (similarity >= 4), add to strengths array
+      if (similarity >= 4) {
+        strengths.push(attributeKey);
+      }
+    });
+
+    // Calculate match percentage (0-100%)
+    // Max possible score is 5 (perfect similarity) weighted by actual weights
+    const maxPossibleWeightedScore = 5 * Object.values(normalizedWeights).reduce((sum, w) => sum + w, 0);
+    const matchPercentage = maxPossibleWeightedScore > 0 ? (totalScore / maxPossibleWeightedScore) * 100 : 0;
+
+    return {
+      device,
+      score: totalScore,
+      matchPercentage: Math.round(matchPercentage),
+      strengths
+    };
+  }).sort((a, b) => b.score - a.score); // Sort by score (highest first)
+};

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -30,5 +30,6 @@ export default defineConfig(({ mode }) => {
         "@research": path.resolve(__dirname, "../research"),
       },
     },
+
   };
 });

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary

Five targeted fixes that address broken recommendation scoring, production deployment routing, translation crash risk, unhandled render errors, and initial bundle size:

1. **Correct scoring algorithm priority-to-attribute mapping** (`RecommendationResults.tsx`) — The `pointWeights` mapping was completely inverted: `easyToUse` mapped to `energy`, `lowPower` to `concurrency`, `lowCost` to `formatEase` AND `cost`, etc. Now correctly maps `easyToUse→formatEase`, `lowPower→energy`, `scalable→growth`, `lowCost→cost`. The `language` priority (no corresponding hardware attribute) is redistributed proportionally among the other 4 priority-driven attributes. Concurrency is derived from the `users` answer instead of priority points. Match percentage now uses actual weight sum instead of hardcoded 5, with a division-by-zero guard.

2. **Guard `t()` with `returnObjects: true` against non-array returns** (`i18n-helpers.ts`, `PDFTemplate.tsx`, `RecommendationResults.tsx`) — New `tArray()` helper wraps `t(key, { returnObjects: true })` with `Array.isArray()` check, returning `[]` for missing keys. Replaces 6 unsafe `.map()` calls that would iterate over individual characters when a translation key is missing.

3. **Fix production router basename** (`.env.production`) — Adds `VITE_ROUTER_BASENAME=/community-box/` so React Router matches routes from the correct base path in production, fixing direct URL access on GitHub Pages.

4. **Add ErrorBoundary** (`ErrorBoundary.tsx`, `App.tsx`, `Questionnaire.tsx`) — Class component error boundary wrapping the route tree (catches fatal errors) and a dedicated boundary around `RecommendationResults` (protects questionnaire progress on render errors). Supports `onReset`, `resetLabel`, and custom `fallback` props. Uses non-destructive retry ("Try Again") for chunk-load failures.

5. **Implement route-level code splitting with retryable lazy loading** (`App.tsx`) — `LandingPage`, `Index`, `DocsHome`, and `MarkdownPage` converted to lazy imports via `retryableLazy` helper. This helper works around React.lazy's cached rejected imports by creating fresh `lazy()` wrappers on retry, falling back to `window.location.reload()` after 2 failed attempts. Suspense fallback shows a loading spinner. Build now produces separate chunks per route.

## Context

Phase 1 of the low-hanging fruit improvements plan. These are the highest-priority fixes addressing broken recommendations, production deployment issues, crash risks, and bundle size.

## Files Changed

| File | Change |
|------|--------|
| `.gitignore` | Added `app/plans/` and agent tool directories |
| `app/.env.production` | Added `VITE_ROUTER_BASENAME=/community-box/` |
| `app/src/App.tsx` | `retryableLazy` helper, `LoadingSpinner`, `AppRoutes` component, `ErrorBoundary` wrapping, `Suspense` |
| `app/src/components/ErrorBoundary.tsx` | New class component with `getDerivedStateFromError`, `componentDidCatch`, configurable reset |
| `app/src/components/PDFTemplate.tsx` | Replaced 2 unsafe `t()` calls with `tArray()` |
| `app/src/components/Questionnaire.tsx` | Wrapped `RecommendationResults` in dedicated `ErrorBoundary` |
| `app/src/components/RecommendationResults.tsx` | Fixed `pointWeights` mapping, language redistribution, concurrency derivation, match % calculation, guarded `answers.users`, replaced 4 unsafe `t()` calls with `tArray()` |
| `app/src/context/QuestionnaireContext.tsx` | Added `skipUrlUpdateRef` to fix `resetSurvey` URL race condition |
| `app/src/lib/i18n-helpers.ts` | New `tArray()` helper for safe `returnObjects` usage |

## Validation

- `npm run lint` — passes cleanly
- `npm run build` — succeeds, produces separate route chunks (LandingPage, DocsHome, MarkdownPage, Index)
- All 12 review threads resolved
- No pending changes requested or approvals blocking

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix device scoring algorithm and add error boundaries, code splitting, and production routing
> - Centralizes device recommendation logic into [deviceScoring.tsx](https://github.com/coolabnet/community-box/pull/39/files#diff-75b9412cd8019b0d34128b0db0085183cda4497267af859a40fc92238bae92bf), fixing normalization mappings and introducing language-point redistribution and concurrency baseline weighting that changes how devices are ranked and scored
> - Adds a reusable [ErrorBoundary](https://github.com/coolabnet/community-box/pull/39/files#diff-cd7d4545b8fdc6296f8b73f16ed459e70bae27b6833e737ac13c6fa5edc4d5b9) component and wraps lazy-loaded routes and `RecommendationResults` with it, providing reset and reload options on failure
> - Splits route components into lazy-loaded chunks via [retryableLazy](https://github.com/coolabnet/community-box/pull/39/files#diff-73b923a7a865109cb391593531ad582df15e836bd976e26a398454bea16f6214), with a `LoadingSpinner` fallback and special handling for chunk-load errors
> - Sets `VITE_ROUTER_BASENAME=/community-box/` in [.env.production](https://github.com/coolabnet/community-box/pull/39/files#diff-8a83c34bfbd7090bd6f25625ae1e6c5947792645818de73424fd85672c927ebd) for correct routing under the production subpath
> - Adds a `tArray` i18n helper to safely return translation arrays, fixing character-by-character iteration bugs in `PDFTemplate` and `RecommendationResults` when keys are missing
> - Risk: scoring changes (normalization scales, weight redistribution) will alter device recommendation results compared to the previous inline algorithm
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f650c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->